### PR TITLE
Extend the LD_LIBRARY_PATH.

### DIFF
--- a/setup.env
+++ b/setup.env
@@ -22,7 +22,7 @@ export SAL_WORK_DIR=$LSST_SDK_INSTALL/test
 export SAL_CPPFLAGS=-m64
 source $SAL_HOME/salenv.sh
 export JAVA_HOME=/etc/alternatives/java_sdk_openjdk
-export LD_LIBRARY_PATH=${SAL_HOME}/lib
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SAL_HOME}/lib
 export TCL_LIBRARY=${SAL_HOME}/lib/tcl8.5
 export TK_LIBRARY=${SAL_HOME}/lib/tk8.5
 export LD_PRELOAD=/etc/alternatives/java_sdk_openjdk/jre/lib/amd64/libjsig.so


### PR DESCRIPTION
Extend the LD_LIBRARY_PATH path variable. If the user sets up the scientific pipeline, LD_LIBRARY_PATH will be assigned with the related packages.