### PR TITLE
Add Documentation build and deployment with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+dist: xenial
+matrix:
+  include:
+    - python: '3.7'
+install:
+  - pip install -r doc/requirements.txt
+  - pip install "ltd-conveyor==0.5.0a1"
+script:
+  - package-docs build
+after_success:
+  - ltd upload --travis --dir doc/_build/html --product ts-sal
+env:
+  global:
+    - LTD_USERNAME=tstravis
+    # LTD_PASSWORD
+    - secure: "EfS7JvsdMv+WOtX8s4koqn4ARuEnMIGGvRQgEeAjdBkPeh4ZGwqjQF/Ng0GJjcxDIFycUm0bCbvQOWdmES5/GXsYUmPl76RmyFEbPODStLY0tULb5zokzKNdf7HpmwxFPcfQEsNkE/qG/XFBWBfJAyZxHDoRUkGY0OiRqxOABWRl0oXCi1DuvG3Kge5M6nJh4Tj05ub0rWYwkq6ly4OoPNhcR4nP2c0Vo80vZUp16pCIi0VCdh78ZF3bVBfeaoZ0VKRWu/CUOrcUhAwQ876dRyJGIbpKj9jRKCO/j8L+9sbVu3qcqY6AY6/ikZkwEX4/tu93AhGalGqDSYAqQ0hG+pji25/w29mjiOtF0Cj85O0cWJD86eanmSqQ/OpCreBpCQZy1SYLDFudirmZmek7sTCbusiMDdhSgHIyvAuyARVnQbUFnJt5LlUB76S0Nio0gMnP/+f33Zs/4VnupdebFZDRd+aTCTydwuSZB52vrXTeY2LQWdv5J8DsyZORnR9Q5UdHs7b2skHWukwD7VV2+ld7oDz6b1jn5djoK9zRET5Fe6v2L/H3tlhxVfrmb+CaRliSbGUTN5Zwp3w2OI4+YTV9DzQCoVAHPerg+nuSVlCXPFeT3UgoNXeNqq63+T0F3iftZu/b7dcw8lIw6Z9/Enm8SGfmcaeJcCd1/vUpJek="

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,10 +4,9 @@ This configuration only affects single-package Sphinx documentation builds.
 """
 
 from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.ts.sal
 
 
 _g = globals()
 _g.update(build_package_configs(
     project_name='ts_sal',
-    version=lsst.ts.sal.__version__))
+    version='0.0.0'))

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,4 +16,12 @@ Using lsst.ts.sal
 ====================
 
 .. toctree::
-    :maxdepth: 2
+   :maxdepth: 2
+
+Project information
+===================
+
+.. toctree::
+   :maxdepth: 2
+
+   revision_history

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+documenteer[pipelines]>=0.5.5


### PR DESCRIPTION
- Adds a documentation build and deployment through Travis CI. This build is a little compromised because we're not actually building an installing `lsst.ts.sal`, so we can't dynamically introspect the software to build documentation. But for the purposes of deploying a documentation site based on reStructuredText, this build environment will do.
- Added the `revision_history` page to a toctree.

See https://ts-sal.lsst.io/v/feature-andrewheyer-DM-22407-jonathansick/index.html

Note: I've set up https://ts-sal.lsst.io so that the main page will reflect the current build of the "develop" branch. We can change this in the future.