### PR TITLE
Support empty component interfaces in `make_*` scripts. 

### DIFF
--- a/bin/make_idl_files.py
+++ b/bin/make_idl_files.py
@@ -41,6 +41,13 @@ if args.all:
     components = lsst.ts.xml.subsystems
 else:
     components = args.components
+    invalid_components = set(components) - set(lsst.ts.xml.subsystems)
+
+    if len(invalid_components) > 0:
+        raise RuntimeError(
+            f"The following components are not part of sal subsystems {invalid_components}. "
+            "Check spelling and try again."
+        )
 if args.exclude:
     exclude = set(args.exclude)
     components = [name for name in components if name not in exclude]

--- a/bin/make_salpy_libs.py
+++ b/bin/make_salpy_libs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import argparse
 
+import lsst.ts.xml
+
 from lsst.ts.sal.make_salpy_lib import make_salpy_lib
 
 parser = argparse.ArgumentParser(
@@ -18,6 +20,14 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
+
+invalid_components = set(args.components) - set(lsst.ts.xml.subsystems)
+
+if len(invalid_components) > 0:
+    raise RuntimeError(
+        f"The following components are not part of sal subsystems {invalid_components}. "
+        "Check spelling and try again."
+    )
 
 for sal_name in args.components:
     make_salpy_lib(sal_name=sal_name, demo=args.demo)

--- a/python/lsst/ts/sal/make_idl_file.py
+++ b/python/lsst/ts/sal/make_idl_file.py
@@ -63,9 +63,19 @@ class MakeIdlFile:
         ]
         sal_xml_paths = glob.glob(os.path.join(interfaces_dir, self.name, "*.xml"))
         if not sal_xml_paths:
-            raise RuntimeError(
-                f"Could not find any XML files for SAL component {self.name}"
+            print(f"Note: SAL component {self.name} only uses generic topics")
+            dummy_xml_event_file = os.path.join(
+                self.sal_work_dir, f"{self.name}_Events.xml"
             )
+            with open(dummy_xml_event_file, "w") as fp:
+                fp.write(
+                    """<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsl"?>
+<SALEventSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsd">
+</SALEventSet>
+"""
+                )
+
         for xmlpath in std_xml_paths + sal_xml_paths:
             shutil.copy(xmlpath, self.sal_work_dir)
 

--- a/python/lsst/ts/sal/make_salpy_lib.py
+++ b/python/lsst/ts/sal/make_salpy_lib.py
@@ -80,9 +80,20 @@ class MakeSalpyLib:
         ]
         sal_xml_paths = glob.glob(os.path.join(interfaces_dir, self.sal_name, "*.xml"))
         if not sal_xml_paths:
-            raise RuntimeError(
-                f"Could not find any XML files for SAL component {self.sal_name}"
+            print(f"Note: SAL component {self.name} only uses generic topics")
+
+            dummy_xml_event_file = os.path.join(
+                self.sal_work_dir, f"{self.sal_name}_Events.xml"
             )
+
+            with open(dummy_xml_event_file, "w") as fp:
+                fp.write(
+                    """<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsl"?>
+<SALEventSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://lsst-sal.tuc.noao.edu/schema/SALEventSet.xsd">
+</SALEventSet>
+"""
+                )
         for xmlpath in std_xml_paths + sal_xml_paths:
             shutil.copy(xmlpath, self.sal_work_dir)
 


### PR DESCRIPTION
Update `make_idl_file.py` and `make_salpy_lib.py` in order to support components with generic topics only.