### PR TITLE
Add tests for CPP and Java to interact with salobj

### DIFF
--- a/bin/minimal_cpp_commander.sh
+++ b/bin/minimal_cpp_commander.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$#" -ne 2 ]; then
+    echo "Arguments required : index logLevel"
+    exit -1
+fi
+
+echo "Starting CPP minimal commander"
+$SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobjTarget $1 $2

--- a/bin/minimal_cpp_commander.sh
+++ b/bin/minimal_cpp_commander.sh
@@ -6,4 +6,4 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting CPP minimal commander"
-$SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobjTarget $1 $2
+/opt/lsst/ts_sal/bin/sacpp_TestWithSalobjTarget $1 $2

--- a/bin/minimal_cpp_controller.sh
+++ b/bin/minimal_cpp_controller.sh
@@ -6,4 +6,4 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting CPP minimal controller"
-$SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobj $1 $2
+/opt/lsst/ts_sal/bin/sacpp_TestWithSalobj $1 $2

--- a/bin/minimal_cpp_controller.sh
+++ b/bin/minimal_cpp_controller.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$#" -ne 2 ]; then
+    echo "Arguments required : index logLevel"
+    exit -1
+fi
+
+echo "Starting CPP minimal controller"
+$SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobj $1 $2

--- a/bin/minimal_java_commander.sh
+++ b/bin/minimal_java_commander.sh
@@ -6,5 +6,5 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting Java minimal commander"
-cd $SAL_WORK_DIR/maven/Test-*$SAL_VERSION
+cd /opt/lsst/ts_sal/maven/Test
 mvn -Dindex=$1 -DlogLevel=$2 -Dtest=TestWithSalobjTargetTest test

--- a/bin/minimal_java_commander.sh
+++ b/bin/minimal_java_commander.sh
@@ -5,6 +5,6 @@ if [ "$#" -ne 2 ]; then
     exit -1
 fi
 
-echo "Starting Java minimal controller"
+echo "Starting Java minimal commander"
 cd $SAL_WORK_DIR/maven/Test-*$SAL_VERSION
-mvn -Dindex=$1 -DlogLevel=$2 -Dtest=TestWithSalobjTest test
+mvn -Dindex=$1 -DlogLevel=$2 -Dtest=TestWithSalobjTargetTest test

--- a/bin/minimal_java_controller.sh
+++ b/bin/minimal_java_controller.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$#" -ne 2 ]; then
+    echo "Arguments required : index logLevel"
+    exit -1
+fi
+
+echo "Starting Java minimal controller"
+cd $SAL_WORK_DIR/maven/Test-$SAL_VERSION*
+mvn -Dindex=$1 -DlogLevel=$2 -Dtest=TestWithSalobjTest test

--- a/bin/minimal_java_controller.sh
+++ b/bin/minimal_java_controller.sh
@@ -6,5 +6,5 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting Java minimal controller"
-cd $SAL_WORK_DIR/maven/Test-*$SAL_VERSION
+cd /opt/lsst/ts_sal/maven/Test
 mvn -Dindex=$1 -DlogLevel=$2 -Dtest=TestWithSalobjTest test

--- a/bin/salgenerator
+++ b/bin/salgenerator
@@ -180,13 +180,11 @@ if { $OPTIONS(validate) || $OPTIONS(idl) } {
   foreach i $all {
     set IDXENUMDONE($i) 0
     if { [file exists $SAL_WORK_DIR/SALGenerics.xml] } {
-      if { [info exists SYSDIC($i,hasGenerics)] || [info exists SYSDIC($i,hasAllGenerics)] } {
-        set x none
-        puts stdout "Add Generic Commands and Events"
-        set SALSubsys $i
-        source $SAL_DIR/processgenerics.tcl
-        generategenerics $i
-      }
+      set x none
+      puts stdout "Add Generic Commands and Events"
+      set SALSubsys $i
+      source $SAL_DIR/processgenerics.tcl
+      generategenerics $i
     }
     set xml ""
     catch { set xml [glob [set i]_*.xml] }

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,11 +6,17 @@
 Version History
 ###############
 
-This is release 6.0.0 of the SAL SDK (September 24th 2021)
+This is release 6.0.0 of the SAL SDK (October 28th 2021)
 -------------------------------------------------------
 
 Changes for 6.0.0
 =================
+
+* Add support for LSST_DDS_ENABLE_AUTHLIST environmetn variable
+
+* Add interlanguage tests for C++ and Java and salobj
+
+* Replace <Generics> with <AddedGenerics> and new selection strategy
 
 * Reset debugLevel=0 for Java 
 

--- a/lsstsal/scripts/code/templates/Makefile.sacpp_TestWithSalobj
+++ b/lsstsal/scripts/code/templates/Makefile.sacpp_TestWithSalobj
@@ -14,10 +14,9 @@ COMPILE.c     = $(CC) $(CFLAGS) $(CPPFLAGS) -c
 COMPILE.cc    = $(CXX) $(CCFLAGS) $(CPPFLAGS) -c
 LDFLAGS       = -fPIC -L"." -L"$(OSPL_HOME)/lib" -Wl,-rpath,\$$ORIGIN -Wl,-rpath,\$$ORIGIN/$(OSPL_HOME)/lib -L"$(SAL_WORK_DIR)/lib"
 CCC           = $(CXX)
-MAKEFILE      = Makefile.sacpp_Test_pybind11
+MAKEFILE      = Makefile.sacpp_TestWithSalobj
 DEPENDENCIES  = 
 BTARGETDIR    = ./
-BIN           = $(BTARGETDIR)SALPY_Test$(SHLIBEXT)
 CAT           = cat
 MV            = mv -f
 RM            = rm -rf
@@ -34,6 +33,8 @@ GENFLAGS      = -g
 LDLIBS        = -l"sacpp_Test_types$(LIBSUFFIX)" -l"dcpssacpp" -l"dcpsgapi" -l"ddsuser" -l"ddskernel" -l"ddsserialization" -l"ddsconfparser" -l"ddsconf" -l"ddsdatabase" -l"ddsutil" -l"ddsos" -ldl $(subst lib,-l,$(sort $(basename $(notdir $(wildcard /usr/lib/librt.so /lib/librt.so))))) -lrt -lpthread
 OBJS          =  .obj/sacpp_TestWithSalobj$(OBJEXT) .obj/SAL_Test$(OBJEXT)
 SRC           =  ../src/sacpp_TestWithSalobj.cpp ../src/SAL_Test.cpp
+OBJS2         =  .obj/sacpp_TestWithSalobjTarget$(OBJEXT) .obj/SAL_Test$(OBJEXT)
+SRC2          =  ../src/sacpp_TestWithSalobjTarget.cpp ../src/SAL_Test.cpp
 LINK.cc       = $(LD) $(LDFLAGS)
 EXPORTFLAGS   = 
 
@@ -41,11 +42,15 @@ EXPORTFLAGS   =
 #       Local targets
 #----------------------------------------------------------------------------
 
-all: sacpp_TestWithSalobj
+all: sacpp_TestWithSalobj sacpp_TestWithSalobjTarget
 
 sacpp_TestWithSalobj: $(OBJS)
 	@$(TESTDIRSTART) "$(BTARGETDIR)" $(TESTDIREND) $(MKDIR) "$(BTARGETDIR)"
 	$(LINK.cc) $(OBJS) $(LDLIBS) $(OUTPUT_OPTION)
+
+sacpp_TestWithSalobjTarget: $(OBJS2)
+	@$(TESTDIRSTART) "$(BTARGETDIR)" $(TESTDIREND) $(MKDIR) "$(BTARGETDIR)"
+	$(LINK.cc) $(OBJS2) $(LDLIBS) $(OUTPUT_OPTION)
 
 generated: $(GENERATED_DIRTY)
 	@-:
@@ -59,11 +64,15 @@ generated: $(GENERATED_DIRTY)
 	@$(TESTDIRSTART) ".obj/../src" $(TESTDIREND) $(MKDIR) ".obj/../src"
 	$(COMPILE.cc) $(EXPORTFLAGS) $(OUTPUT_OPTION) ../src/sacpp_TestWithSalobj.cpp
 
+.obj/sacpp_TestWithSalobjTarget$(OBJEXT): ../src/sacpp_TestWithSalobjTarget.cpp
+	@$(TESTDIRSTART) ".obj/../src" $(TESTDIREND) $(MKDIR) ".obj/../src"
+	$(COMPILE.cc) $(EXPORTFLAGS) $(OUTPUT_OPTION) ../src/sacpp_TestWithSalobjTarget.cpp
+
 clean:
-	-$(RM) $(OBJS)
+	-$(RM) $(OBJS) $(OBJS2)
 
 realclean: clean
-	-$(RM) $(BIN)
+	-$(RM) sacpp_TestWithSalobj sacpp_TestWithSalobjTarget
 	-$(RM) .obj/
 
 check-syntax:

--- a/lsstsal/scripts/code/templates/Makefile.sacpp_TestWithSalobj
+++ b/lsstsal/scripts/code/templates/Makefile.sacpp_TestWithSalobj
@@ -1,0 +1,82 @@
+#----------------------------------------------------------------------------
+#       Macros
+#----------------------------------------------------------------------------
+CC            = gcc
+CXX           = g++
+CPPFLAGS      = $(PICFLAGS) $(GENFLAGS) $(SAL_CPPFLAGS) -Wno-write-strings -std=c++11 -D_REENTRANT -Wall -I"." -I"$(OSPL_HOME)/examples/include" -I"$(OSPL_HOME)/examples" -I"$(OSPL_HOME)/include" -I"$(OSPL_HOME)/include/sys" -I"$(OSPL_HOME)/include/dcps/C++/SACPP" -I"$(SAL_HOME)/include" -I../../../Test/cpp/src -I../../../Test/cpp -DSAL_SUBSYSTEM_ID_IS_KEYED
+LD            = $(CXX) $(CCFLAGS) $(CPPFLAGS)
+AR            = ar
+PICFLAGS      = -fPIC
+OBJEXT        = .o
+SHLIBEXT      = .so
+OUTPUT_OPTION = -o "$@"
+COMPILE.c     = $(CC) $(CFLAGS) $(CPPFLAGS) -c
+COMPILE.cc    = $(CXX) $(CCFLAGS) $(CPPFLAGS) -c
+LDFLAGS       = -fPIC -L"." -L"$(OSPL_HOME)/lib" -Wl,-rpath,\$$ORIGIN -Wl,-rpath,\$$ORIGIN/$(OSPL_HOME)/lib -L"$(SAL_WORK_DIR)/lib"
+CCC           = $(CXX)
+MAKEFILE      = Makefile.sacpp_Test_pybind11
+DEPENDENCIES  = 
+BTARGETDIR    = ./
+BIN           = $(BTARGETDIR)SALPY_Test$(SHLIBEXT)
+CAT           = cat
+MV            = mv -f
+RM            = rm -rf
+CP            = cp -p
+NUL           = /dev/null
+MKDIR         = mkdir -p
+TESTDIRSTART  = test -d
+TESTDIREND    = ||
+TOUCH         = touch
+EXEEXT        = 
+LIBPREFIX     = lib
+LIBSUFFIX     = 
+GENFLAGS      = -g
+LDLIBS        = -l"sacpp_Test_types$(LIBSUFFIX)" -l"dcpssacpp" -l"dcpsgapi" -l"ddsuser" -l"ddskernel" -l"ddsserialization" -l"ddsconfparser" -l"ddsconf" -l"ddsdatabase" -l"ddsutil" -l"ddsos" -ldl $(subst lib,-l,$(sort $(basename $(notdir $(wildcard /usr/lib/librt.so /lib/librt.so))))) -lrt -lpthread
+OBJS          =  .obj/sacpp_TestWithSalobj$(OBJEXT) .obj/SAL_Test$(OBJEXT)
+SRC           =  ../src/sacpp_TestWithSalobj.cpp ../src/SAL_Test.cpp
+LINK.cc       = $(LD) $(LDFLAGS)
+EXPORTFLAGS   = 
+
+#----------------------------------------------------------------------------
+#       Local targets
+#----------------------------------------------------------------------------
+
+all: sacpp_TestWithSalobj
+
+sacpp_TestWithSalobj: $(OBJS)
+	@$(TESTDIRSTART) "$(BTARGETDIR)" $(TESTDIREND) $(MKDIR) "$(BTARGETDIR)"
+	$(LINK.cc) $(OBJS) $(LDLIBS) $(OUTPUT_OPTION)
+
+generated: $(GENERATED_DIRTY)
+	@-:
+
+
+.obj/SAL_Test$(OBJEXT): ../src/SAL_Test.cpp
+	@$(TESTDIRSTART) ".obj/../src" $(TESTDIREND) $(MKDIR) ".obj/../src"
+	$(COMPILE.cc) $(EXPORTFLAGS) $(OUTPUT_OPTION) ../src/SAL_Test.cpp
+
+.obj/sacpp_TestWithSalobj$(OBJEXT): ../src/sacpp_TestWithSalobj.cpp
+	@$(TESTDIRSTART) ".obj/../src" $(TESTDIREND) $(MKDIR) ".obj/../src"
+	$(COMPILE.cc) $(EXPORTFLAGS) $(OUTPUT_OPTION) ../src/sacpp_TestWithSalobj.cpp
+
+clean:
+	-$(RM) $(OBJS)
+
+realclean: clean
+	-$(RM) $(BIN)
+	-$(RM) .obj/
+
+check-syntax:
+	$(COMPILE.cc) $(EXPORTFLAGS) -Wall -Wextra -pedantic -fsyntax-only $(CHK_SOURCES)
+
+#----------------------------------------------------------------------------
+#       Dependencies
+#----------------------------------------------------------------------------
+
+$(DEPENDENCIES):
+	@$(TOUCH) $(DEPENDENCIES)
+
+depend:
+	-VDIR=.obj/ $(MPC_ROOT)/depgen.pl  $(CFLAGS) $(CCFLAGS) $(CPPFLAGS) -f $(DEPENDENCIES) $(SRC) 2> $(NUL)
+
+include $(DEPENDENCIES)

--- a/lsstsal/scripts/code/templates/SALDDS.cpp-cmd.template
+++ b/lsstsal/scripts/code/templates/SALDDS.cpp-cmd.template
@@ -137,6 +137,9 @@ salReturn SAL_SALData::checkAuthList(std::string private_identity)
   std::string my_identity = CSC_identity;
   SALData_command_setAuthListC SALInstance;
   SALData_logevent_authListC myData;
+
+  if ( !authListEnabled ) return SAL__OK;
+
   if ( sal[SAL__SALData_command_setAuthList_ACTOR].isProcessor == false ) {
      status = salProcessor("SALData_command_setAuthList");
      status = salEventPub("SALData_logevent_authList");

--- a/lsstsal/scripts/code/templates/SALDDS.cpp.template
+++ b/lsstsal/scripts/code/templates/SALDDS.cpp.template
@@ -48,9 +48,11 @@ SAL_SALData::SAL_SALData(char *identity)
 
 void SAL_SALData::initSalEnvironment(int aKey)
 {
+   int aenable;
    char *pname = getenv("LSST_DDS_PARTITION_PREFIX");
    char *qname = getenv("LSST_DDS_QOS");
    char *sname = getenv("LSST_DDS_HISTORYSYNC");
+   char *aname = getenv("LSST_DDS_ENABLE_AUTHLIST");
    if ( pname != NULL ) {
       strncpy(partitionPrefix, pname, 128);
    } else {
@@ -68,6 +70,13 @@ void SAL_SALData::initSalEnvironment(int aKey)
       sscanf(sname,"%d",&historySync);
    } else {
       historySync = 0;
+   }
+   authListEnabled = false;
+   if ( aname != NULL ) {
+      sscanf(aname,"%d",&aenable);
+      if (aenable == 1) {
+        authListEnabled = true;
+      }
    }
    hasReader = false;
    hasWriter = false;

--- a/lsstsal/scripts/code/templates/SALDDS.h.template
+++ b/lsstsal/scripts/code/templates/SALDDS.h.template
@@ -213,6 +213,7 @@
       int lastActor_telemetry;
       int lastActor_command;
       int lastActor_event;
+      bool authListEnabled;
 
 ///   Holds the private_identity of this SAL Object, set at creation
       char CSC_identity[128];

--- a/lsstsal/scripts/code/templates/SALDDS.java.template
+++ b/lsstsal/scripts/code/templates/SALDDS.java.template
@@ -86,7 +86,8 @@ public class SAL_SALData {
         private String CSC_identity;
         private String authorizedUsers;
         private String nonAuthorizedCSCs;
- 
+        private Boolean authListEnabled;
+
         salUtils salUtil = new salUtils();
         salActor[] sal = new salActor[SAL__ACTORS_MAXCOUNT];
 
@@ -271,6 +272,7 @@ public class SAL_SALData {
                 String pname = System.getenv("LSST_DDS_PARTITION_PREFIX");
                 String hname = System.getenv("LSST_DDS_HISTORYSYNC");
                 String qname = System.getenv("LSST_DDS_QOS");
+                String aname = System.getenv("LSST_DDS_ENABLE_AUTHLIST");
                 if (pname != null) {
                    partitionPrefix = pname;
                 } else {
@@ -286,6 +288,12 @@ public class SAL_SALData {
                   eventQos = new QosProvider(qname,"EventProfile");
                   telemetryQos = new QosProvider(qname,"TelemetryProfile");
                   ackcmdQos = new QosProvider(qname,"AckcmdProfile");
+                }
+                authListEnabled = false;
+                if (aname != null) {
+                  if (Integer.valueOf(aname) == 1) {
+                    authListEnabled = true;
+                  } 
                 }
                 origin = (int)randGen.nextInt(99999999);
 		hasReader = false;

--- a/lsstsal/scripts/code/templates/TestWithSalobjTargetTest.java
+++ b/lsstsal/scripts/code/templates/TestWithSalobjTargetTest.java
@@ -1,0 +1,134 @@
+/**
+ * This file contains the implementation for the TestWithSalobjTarget test.
+ *
+ * This file is part of ts_sal.
+ *
+ * Developed for the Rubin Observatory Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.lsst.sal.junit.Test;
+
+import junit.framework.TestCase;
+import java.lang.Integer;
+import Test.*;
+import org.lsst.sal.SAL_Test;
+
+public class TestWithSalobjTargetTest extends TestCase {
+
+   	public TestWithSalobjTargetTest(String name) {
+   	   super(name);
+   	}
+
+	public static final int STD_TIMEOUT = 60;
+
+	public void testTestWithSalobjTarget() {
+
+          int cmdid;
+	  int status;
+          int itimer;
+          int ilevel;
+	  int loglevels[] = { 10, 52, 0 };
+
+          Test.logevent_logLevel SALEvent = new Test.logevent_logLevel();
+          Test.command_setLogLevel SALCommand = new Test.command_setLogLevel();
+          Test.scalars SALTelemetry = new Test.scalars() ;
+          Integer index = Integer.valueOf(System.getProperty("index"));
+          Integer logLevel = Integer.valueOf(System.getProperty("logLevel"));
+	  SAL_Test mgr = new SAL_Test( (int) index);
+
+          mgr.setDebugLevel(2);
+          mgr.salEventSub("Test_logevent_logLevel");
+          mgr.salTelemetrySub("Test_scalars");
+          mgr.salCommand("Test_command_setLogLevel");
+
+          System.out.println("SALCommander: waiting for initial logLevel.level " + logLevel);
+
+	  status = mgr.getEvent_logLevel(SALEvent);
+	  itimer = 0;
+	  while (status != SAL_Test.SAL__OK) {
+	    status = mgr.getEvent_logLevel(SALEvent);
+            try {Thread.sleep(10);} catch (InterruptedException e)  { e.printStackTrace(); }
+	    itimer++;
+	    if (itimer > STD_TIMEOUT*100) {
+	      System.out.println("SALCommmander: timed out for getEvent_logLevel");
+	      System.exit(-1);
+	    }
+	  }
+
+	  if (SALEvent.level != logLevel) {
+	    System.out.println("SALCommmander: unexpected logLevel received " + SALEvent.level);
+	    System.exit(-2);
+	  }
+
+	  for ( ilevel=0;ilevel<3;ilevel++ ) {
+
+	    SALCommand.level = loglevels[ilevel];
+	    cmdid = mgr.issueCommand_setLogLevel(SALCommand);
+	    System.out.println("SALCommmander:  send setLogLevel(level=" + SALCommand.level + ") command");
+
+	    status = mgr.waitForCompletion_setLogLevel(cmdid, 60);
+	    if (status != SAL_Test.SAL__CMD_COMPLETE) {
+	      System.out.println("SALCommmander: timed out for ackcmd setLogLevel");
+	      System.exit(-3);
+	    }
+
+	    status = SAL_Test.SAL__ERR;
+	    itimer = 0;
+	    while (status != SAL_Test.SAL__OK) {
+	      status = mgr.getEvent_logLevel(SALEvent);
+              try {Thread.sleep(10);} catch (InterruptedException e)  { e.printStackTrace(); }
+	      itimer++;
+	      if (itimer > STD_TIMEOUT*100) {
+	        System.out.println("SALCommmander: timed out for getEvent_logLevel");
+	        System.exit(-4);
+	      }
+	    }
+	    if (SALEvent.level != loglevels[ilevel]) {
+	      System.out.println("SALCommmander: unexpected logLevel logEvent received " + SALEvent.level);
+	      System.exit(-5);
+	    }
+
+	    status = SAL_Test.SAL__ERR;
+	    itimer = 0;
+	    while (status != SAL_Test.SAL__OK) {
+	      status = mgr.getSample(SALTelemetry);
+              try {Thread.sleep(10);} catch (InterruptedException e)  { e.printStackTrace(); }
+	      itimer++;
+	      if (itimer > STD_TIMEOUT*100) {
+	        System.out.println("SALCommmander: timed out for getSample_scalars");
+	        System.exit(-6);
+	      }
+	    }
+	    if (SALTelemetry.int0 != loglevels[ilevel]) {
+	      System.out.println("SALCommmander: unexpected logLevel telemetry received " + SALTelemetry.int0);
+	      System.exit(-7);
+	    }
+
+	  }
+
+	  // Remove the DataWriters etc
+          System.out.println("SALCommander: completed");
+          try{Thread.sleep(1000);} catch (InterruptedException e)  { e.printStackTrace(); }
+          mgr.salShutdown();
+        }
+
+}
+
+

--- a/lsstsal/scripts/code/templates/TestWithSalobjTest.java
+++ b/lsstsal/scripts/code/templates/TestWithSalobjTest.java
@@ -1,0 +1,68 @@
+
+
+
+// This file contains the implementation for the TestWithSalobj test.
+package org.lsst.sal.junit.Test;
+
+import junit.framework.TestCase;
+import java.lang.Integer;
+import Test.*;
+import org.lsst.sal.SAL_Test;
+
+public class TestWithSalobjTest extends TestCase {
+
+   	public TestWithSalobjTest(String name) {
+   	   super(name);
+   	}
+
+	public void testTestWithSalobj() {
+
+          int cmdid;
+
+          Test.logevent_logLevel SALEvent = new Test.logevent_logLevel();
+          Test.command_setLogLevel SALCommand = new Test.command_setLogLevel();
+          Test.scalars SALTelemetry = new Test.scalars() ;
+          Integer index = Integer.valueOf(System.getProperty("index"));
+          Integer logLevel = Integer.valueOf(System.getProperty("logLevel"));
+	  SAL_Test mgr = new SAL_Test( (int) index);
+
+          mgr.salEventPub("Test_logevent_logLevel");
+          mgr.salTelemetryPub("Test_scalars");
+          mgr.salProcessor("Test_command_setLogLevel");
+
+          System.out.println("SALController: writing initial logLevel.level " + logLevel);
+          SALEvent.level = logLevel;
+          mgr.logEvent_logLevel(SALEvent,1);
+
+          while (true) {
+// receive event
+          cmdid = mgr.acceptCommand_setLogLevel(SALCommand);
+
+            if (cmdid < 0) {
+              System.out.println( "SALController: error reading setLogLevel command; cmdid=" + cmdid);
+            } else {
+              if ( cmdid > 0 ) {
+                System.out.println("SALController: read setLogLevel(cmdid=" + cmdid + ";level=" + SALCommand.level + ")");
+                mgr.ackCommand_setLogLevel(cmdid, SAL_Test.SAL__CMD_COMPLETE, 0, "Done : OK");
+                try {Thread.sleep(10);} catch (InterruptedException e)  { e.printStackTrace(); }
+                System.out.println("SALController: writing logLevel=" + SALCommand.level + " event and the same value in scalars.int0 telemetry");
+                SALTelemetry.int0 = SALCommand.level;
+                SALEvent.level = SALCommand.level;
+                mgr.logEvent_logLevel(SALEvent,1);
+                mgr.putSample(SALTelemetry);
+                try {Thread.sleep(10);} catch (InterruptedException e)  { e.printStackTrace(); }
+                if (SALCommand.level == 0) break;
+              }
+            }
+            try {Thread.sleep(1000);} catch (InterruptedException e)  { e.printStackTrace(); }
+          }
+
+// Remove the DataWriters etc
+          System.out.println("SALController: quitting");
+          try{Thread.sleep(1000);} catch (InterruptedException e)  { e.printStackTrace(); }
+          mgr.salShutdown();
+      }
+
+}
+
+

--- a/lsstsal/scripts/code/templates/TestWithSalobjTest.java
+++ b/lsstsal/scripts/code/templates/TestWithSalobjTest.java
@@ -1,7 +1,29 @@
+/**
+ * This file contains the implementation for the TestWithSalobj test.
+ *
+ * This file is part of ts_sal.
+ *
+ * Developed for the Rubin Observatory Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 
-
-// This file contains the implementation for the TestWithSalobj test.
 package org.lsst.sal.junit.Test;
 
 import junit.framework.TestCase;
@@ -26,6 +48,7 @@ public class TestWithSalobjTest extends TestCase {
           Integer logLevel = Integer.valueOf(System.getProperty("logLevel"));
 	  SAL_Test mgr = new SAL_Test( (int) index);
 
+          mgr.setDebugLevel(2);
           mgr.salEventPub("Test_logevent_logLevel");
           mgr.salTelemetryPub("Test_scalars");
           mgr.salProcessor("Test_command_setLogLevel");
@@ -58,7 +81,7 @@ public class TestWithSalobjTest extends TestCase {
           }
 
 // Remove the DataWriters etc
-          System.out.println("SALController: quitting");
+          System.out.println("SALController: completed");
           try{Thread.sleep(1000);} catch (InterruptedException e)  { e.printStackTrace(); }
           mgr.salShutdown();
       }

--- a/lsstsal/scripts/code/templates/sacpp_TestWithSalobj.cpp
+++ b/lsstsal/scripts/code/templates/sacpp_TestWithSalobj.cpp
@@ -1,8 +1,27 @@
-
-
 /*
  * This file contains the implementation for the TestWithSalobj test.
  *
+ *
+ * This file is part of ts_sal.
+ *
+ * Developed for the Rubin Observatory Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  ***/
 
 #include <string>
@@ -60,7 +79,7 @@ int test_TestWithSalobj(int index, int logLevel)
   }
 
   // Remove the DataWriters etc
-  cout << "SALController: quitting" << endl;
+  cout << "SALController: completed" << endl;
   sleep(1);
   mgr.salShutdown();
 

--- a/lsstsal/scripts/code/templates/sacpp_TestWithSalobj.cpp
+++ b/lsstsal/scripts/code/templates/sacpp_TestWithSalobj.cpp
@@ -1,0 +1,88 @@
+
+
+/*
+ * This file contains the implementation for the TestWithSalobj test.
+ *
+ ***/
+
+#include <string>
+#include <sstream>
+#include <iostream>
+#include "SAL_Test.h"
+#include "ccpp_sal_Test.h"
+#include "os.h"
+#include <stdlib.h>
+
+
+using namespace DDS;
+using namespace Test;
+
+int test_TestWithSalobj(int index, int logLevel)
+{ 
+  int cmdid;
+  os_time delay_10ms = { 0, 10000000 };
+
+  Test_logevent_logLevelC SALEvent;
+  Test_command_setLogLevelC SALCommand;
+  Test_scalarsC SALTelemetry;
+  SAL_Test mgr = SAL_Test(index);
+
+
+  mgr.salEventPub("Test_logevent_logLevel");
+  mgr.salTelemetryPub("Test_scalars");
+  mgr.salProcessor("Test_command_setLogLevel");
+
+  cout << "SALController: writing initial logLevel.level " << logLevel << endl;
+  SALEvent.level = logLevel;
+  mgr.logEvent_logLevel(&SALEvent,1);
+
+  while (1) {
+  // receive event
+    cmdid = mgr.acceptCommand_setLogLevel(&SALCommand);
+
+    if (cmdid < 0) {
+      cout << "SALController: error reading setLogLevel command; cmdid=" << cmdid << endl;
+    } else {
+      if ( cmdid > 0 ) {
+        cout << "SALController: read setLogLevel(cmdid=" << cmdid << ";level=" << SALCommand.level << endl;
+        mgr.ackCommand_setLogLevel(cmdid, SAL__CMD_COMPLETE, 0, "Done : OK");
+        os_nanoSleep(delay_10ms);
+        cout << "SALController: writing logLevel=" << SALCommand.level << " event and the same value in scalars.int0 telemetry" << endl;
+        SALTelemetry.int0 = SALCommand.level;
+        SALEvent.level = SALCommand.level;
+        mgr.logEvent_logLevel(&SALEvent,1);
+        mgr.putSample_scalars(&SALTelemetry);
+        os_nanoSleep(delay_10ms);
+        if (SALCommand.level == 0) break;
+      }
+    }
+    os_nanoSleep(delay_10ms);
+  }
+
+  // Remove the DataWriters etc
+  cout << "SALController: quitting" << endl;
+  sleep(1);
+  mgr.salShutdown();
+
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[])
+{
+  int index, logLevel;
+
+  if ( argc < 2 ) {
+    cout << "Arguments required : index logLevel" << endl;
+    exit(-1);
+  }
+  index=strtol(argv[1],NULL,10);
+  logLevel=strtol(argv[2],NULL,10);
+  cout << "SALController: starting with index=" << index << ", initial_log_level=" << logLevel << endl;
+  return test_TestWithSalobj(index,logLevel);
+}
+
+
+
+

--- a/lsstsal/scripts/code/templates/sacpp_TestWithSalobjTarget.cpp
+++ b/lsstsal/scripts/code/templates/sacpp_TestWithSalobjTarget.cpp
@@ -1,0 +1,150 @@
+/*
+ * This file contains the implementation for the TestWithSalobjTarget test.
+ *
+ * This file is part of ts_sal.
+ *
+ * Developed for the Rubin Observatory Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ ***/
+
+#include <string>
+#include <sstream>
+#include <iostream>
+#include "SAL_Test.h"
+#include "ccpp_sal_Test.h"
+#include "os.h"
+#include <stdlib.h>
+
+#define STD_TIMEOUT 60
+
+using namespace DDS;
+using namespace Test;
+
+int test_TestWithSalobjTarget(int index, int logLevel)
+{ 
+  int cmdid;
+  os_time delay_10ms = { 0, 10000000 };
+  int loglevels[] = { 10, 52, 0 };
+  int ilevel;
+  int itimer;
+  int status;
+
+  Test_logevent_logLevelC SALEvent;
+  Test_command_setLogLevelC SALCommand;
+  Test_ackcmdC SALAckcmd;
+  Test_scalarsC SALTelemetry;
+  SAL_Test mgr = SAL_Test(index);
+
+
+  mgr.salEventSub("Test_logevent_logLevel");
+  mgr.salTelemetrySub("Test_scalars");
+  mgr.salCommand("Test_command_setLogLevel");
+
+  cout << "SALCommmander: wait for initial logLevel" << endl;
+  status = mgr.getEvent_logLevel(&SALEvent);
+  itimer = 0;
+  while (status != SAL__OK) {
+    status = mgr.getEvent_logLevel(&SALEvent);
+    os_nanoSleep(delay_10ms);
+    itimer++;
+    if (itimer > STD_TIMEOUT*100) {
+      cout << "SALCommmander: timed out for getEvent_logLevel" << endl;
+      exit(-1);
+    }
+  }
+
+  if (SALEvent.level != logLevel) {
+    cout << "SALCommmander: unexpected logLevel received" << SALEvent.level << endl;
+    exit(-2);
+  }
+
+  for ( ilevel=0;ilevel<3;ilevel++ ) {
+
+    SALCommand.level = loglevels[ilevel];
+    cmdid = mgr.issueCommand_setLogLevel(&SALCommand);
+    cout << "SALCommmander:  send setLogLevel(level=" << SALCommand.level << ") command" << endl;
+
+    status = mgr.waitForCompletion_setLogLevel(cmdid, STD_TIMEOUT);
+    if (status != SAL__CMD_COMPLETE) {
+     cout << "SALCommmander: timed out for ackcmd setLogLevel" << endl;
+     exit(-3);
+    }
+
+    status = SAL__ERR;
+    itimer = 0;
+    while (status != SAL__OK) {
+      status = mgr.getEvent_logLevel(&SALEvent);
+      os_nanoSleep(delay_10ms);
+      itimer++;
+      if (itimer > STD_TIMEOUT*100) {
+        cout << "SALCommmander: timed out for getEvent_logLevel" << endl;
+        exit(-4);
+      }
+    }
+    if (SALEvent.level != loglevels[ilevel]) {
+      cout << "SALCommmander: unexpected logLevel logEvent received " << SALEvent.level << endl;
+      exit(-5);
+    }
+
+    status = SAL__ERR;
+    itimer = 0;
+    while (status != SAL__OK) {
+      status = mgr.getSample_scalars(&SALTelemetry);
+      os_nanoSleep(delay_10ms);
+      itimer++;
+      if (itimer > STD_TIMEOUT*100) {
+        cout << "SALCommmander: timed out for getSample_scalars" << endl;
+        exit(-6);
+      }
+    }
+    if (SALTelemetry.int0 != loglevels[ilevel]) {
+      cout << "SALCommmander: unexpected logLevel telemetry received " << SALTelemetry.int0 << endl;
+      exit(-7);
+    }
+
+  }
+
+
+
+  // Remove the DataWriters etc
+  cout << "SALCommander: completed" << endl;
+  sleep(1);
+  mgr.salShutdown();
+
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[])
+{
+  int index, logLevel;
+  if ( argc < 2 ) {
+    cout << "Arguments required : index" << endl;
+    exit(-1);
+  }
+  index=strtol(argv[1],NULL,10);
+  logLevel=strtol(argv[2],NULL,10);
+  cout << "SALController: starting with index=" << index << ", initial_log_level=" << logLevel << endl;
+  return test_TestWithSalobjTarget(index,logLevel);
+}
+
+
+
+

--- a/lsstsal/scripts/gencmdaliascode.tcl
+++ b/lsstsal/scripts/gencmdaliascode.tcl
@@ -1091,7 +1091,7 @@ global SYSDIC
   	  // Filter expr
           String expr\[\] = new String\[0\];
           String sFilter = \"SALDataID = \" + subsystemID;
-          String fCmd = \"filteredCmd\" + sal\[actorIdx\].topicHandle;
+          String fCmd = \"filteredCmd_\" + sal\[actorIdx\].topicHandle;
     	  createContentFilteredTopic(actorIdx,fCmd, sFilter, expr);
  	  createReader(actorIdx,false);
 "

--- a/lsstsal/scripts/gencmdaliascode.tcl
+++ b/lsstsal/scripts/gencmdaliascode.tcl
@@ -1131,6 +1131,11 @@ global SYSDIC
           int cmdId;
           int iat = 0;
   	  String my_identity = CSC_identity;
+
+          if ( !authListEnabled ) \{
+             return SAL__OK;
+          \}
+
           boolean defaultCheck = private_identity.equals(CSC_identity);
           if (defaultCheck) \{
              return SAL__OK;

--- a/lsstsal/scripts/gencommandtests.tcl
+++ b/lsstsal/scripts/gencommandtests.tcl
@@ -21,7 +21,7 @@
 #  per-command Topic type. 
 #
 proc gencommandtestscpp { subsys } {
-global CMD_ALIASES CMDS SAL_WORK_DIR SYSDIC DONE_CMDEVT OPTIONS
+global CMD_ALIASES CMDS SAL_WORK_DIR SAL_DIR SYSDIC DONE_CMDEVT OPTIONS
  if { $OPTIONS(verbose) } {stdlog "###TRACE>>> gencommandtestscpp $subsys"}
  if { $subsys == "LOVE" } {return}
  if { [info exists CMD_ALIASES($subsys)] && $DONE_CMDEVT == 0 } {

--- a/lsstsal/scripts/gencommandtests.tcl
+++ b/lsstsal/scripts/gencommandtests.tcl
@@ -281,6 +281,7 @@ global CMD_ALIASES CMDS SAL_WORK_DIR SYSDIC DONE_CMDEVT SAL_DIR OPTIONS
   set testnoauth "MTM1M3"
   if { $subsys == "MTM1M3" } {set testnoauth "MTRotator"}
   puts $fout "#!/bin/sh
+export LSST_DDS_ENABLE_AUTHLIST=1
 echo \"=====================================================================\"
 echo \"Starting sacpp_[set subsys]_setLogLevel_controller\"
 $SAL_WORK_DIR/[set subsys]/cpp/src/sacpp_[set subsys]_setLogLevel_controller &

--- a/lsstsal/scripts/gencommandtestsjava.tcl
+++ b/lsstsal/scripts/gencommandtestsjava.tcl
@@ -236,6 +236,7 @@ mvn -q -Dtest=[set subsys]Commander_setAuthListTest.java test
       set testnoauth "MTM1M3"
       if { $subsys == "MTM1M3" } {set testnoauth "MTRotator"}
       puts $fout "#!/bin/sh
+export LSST_DDS_ENABLE_AUTHLIST=1
 echo \"=====================================================================\"
 echo \"Starting java_[set subsys]_setLogLevel_controller\"
 $SAL_WORK_DIR/[set subsys]/java/src/java_[set subsys]_setLogLevel_controller &

--- a/lsstsal/scripts/gensalgetput.tcl
+++ b/lsstsal/scripts/gensalgetput.tcl
@@ -265,8 +265,13 @@ string SAL_SALData::getXMLVersion()
 
 string SAL_SALData::getOSPLVersion()
 \{
-     string osplver = getenv(\"OSPL_RELEASE\");
-     return osplver;
+     string osplversion;
+     char *osplrelease = getenv(\"OSPL_RELEASE\");
+     if (osplrelease == NULL) \{
+        throw std::runtime_error(\"getOSPLVersion failed: OSPL_RELEASE environment not setup\");
+     \}
+     osplversion = osplrelease;
+     return osplversion;
 \}
 "
 }
@@ -297,9 +302,12 @@ public String getXMLVersion()
 /// Returns the current OpenSpliceDDS version e.g. \"6.9.181127OSS\"
 public String getOSPLVersion()
 \{
-    String osplver = System.getenv(\"OSPL_RELEASE\");
-    return osplver;
-\}
+  String osplrelease = System.getenv(\"OSPL_RELEASE\");
+    if (osplrelease == null) \{
+      System.out.println(\"Error in getOSPLVersion: OSPL_RELEASE environment not setup\");
+      System.exit(-1);
+    \}
+    return osplrelease;\}
 "
 }
 

--- a/lsstsal/scripts/gensalgetput.tcl
+++ b/lsstsal/scripts/gensalgetput.tcl
@@ -727,8 +727,9 @@ global env SAL_DIR SAL_WORK_DIR SYSDIC TLMS EVTS OPTIONS
     sal\[actorIdx\].sndSeqNum++;
     if (debugLevel > 0) \{
       System.out.println(\"=== \[putSample $name\] writing a message containing :\");
-      System.out.println(\"    revCode  : \" + SALInstance.private_revCode);
-      System.out.println(\"    sndStamp  : \" + SALInstance.private_sndStamp);
+      System.out.println(\"  revCode  : \" + SALInstance.private_revCode);
+      System.out.println(\"  sndStamp  : \" + SALInstance.private_sndStamp);
+      System.out.println(\"  identity : \" + SALInstance.private_identity);
     \}"
         copytojavasample $fout $base $name
         if { [info exists SYSDIC($base,keyedID)] } {
@@ -786,12 +787,12 @@ global env SAL_DIR SAL_WORK_DIR SYSDIC TLMS EVTS OPTIONS
       if (debugLevel > 0) \{
     for (int i = 0; i < numsamp; i++) \{
         System.out.println(\"=== \[getSample $name \] message received :\" + i);
-        System.out.println(\"    revCode  : \"
-            + SALInstance.value\[i\].private_revCode);
-              System.out.println(\"     sndStamp  : \" + SALInstance.value\[i\].private_sndStamp);
+        System.out.println(\"  revCode  : \" + SALInstance.value\[i\].private_revCode);
+        System.out.println(\"  identity : \" + SALInstance.value\[i\].private_identity);
+        System.out.println(\"  sndStamp  : \" + SALInstance.value\[i\].private_sndStamp);
         System.out.println(\"  sample_state : \" + infoSeq.value\[i\].sample_state);
-        System.out.println(\"    view_state : \" + infoSeq.value\[i\].view_state);
-        System.out.println(\"instance_state : \" + infoSeq.value\[i\].instance_state);
+        System.out.println(\"  view_state : \" + infoSeq.value\[i\].view_state);
+        System.out.println(\"  instance_state : \" + infoSeq.value\[i\].instance_state);
     \}
       \}
             int j=numsamp-1;

--- a/lsstsal/scripts/gensalrpms.tcl
+++ b/lsstsal/scripts/gensalrpms.tcl
@@ -38,6 +38,28 @@ global OPTIONS
     }
 }
 
+
+#
+## Documented proc \c copylangtests .
+# \param[in] asset Path a file to include in the RPM
+# \param[in] dest Destination directory for copy
+#
+proc copylangtests { rpmname } {
+global OPTIONS SAL_DIR SALVERSION XMLVERSION SAL_WORK_DIR
+    if { $OPTIONS(verbose) } {puts stdout "###TRACE>>> copylangtests"}
+    copyasset $SAL_DIR/../../bin/minimal_cpp_commander.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
+    copyasset $SAL_DIR/../../bin/minimal_cpp_controller.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
+    copyasset $SAL_DIR/../../bin/minimal_java_commander.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
+    copyasset $SAL_DIR/../../bin/minimal_java_controller.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
+    copyasset $SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobj [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
+    copyasset $SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobjTarget [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
+    exec mkdir -p [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven
+    exec cp -r $SAL_WORK_DIR/maven/Test-[set XMLVERSION]_[set SALVERSION] [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven/.
+    exec mv [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven/Test-[set XMLVERSION]_[set SALVERSION] [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven/Test
+    if { $OPTIONS(verbose) } {puts stdout "###TRACE<<< copylangtests"}
+}
+
+
 #
 ## Documented proc \c updatetests .
 # \param[in] subsys Name of CSC/SUbsystem as defined in SALSubsystems.xml
@@ -65,6 +87,9 @@ global SAL_WORK_DIR XMLVERSION
          copyasset $i [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
          puts stdout "Done $subsys $i"
       }
+    }
+    if { $subsys == "Test" } {
+      copylangtests $rpmname
     }
   }
 }

--- a/lsstsal/scripts/gensimplesample.tcl
+++ b/lsstsal/scripts/gensimplesample.tcl
@@ -1062,7 +1062,7 @@ global SAL_WORK_DIR OPTIONS
 #  Generate C++ test program for a SAL Topic
 #
 proc salcpptestgen { base id } {
-global SAL_WORK_DIR OPTIONS DONE_CMDEVT
+global SAL_WORK_DIR SAL_DIR OPTIONS DONE_CMDEVT
   if { $OPTIONS(verbose) } {stdlog "###TRACE>>> salcpptestgen $base $id"}
   if { $OPTIONS(fastest) == 0 } {
     if { $id != "[set base]_notused" } {
@@ -1089,6 +1089,12 @@ global SAL_WORK_DIR OPTIONS DONE_CMDEVT
    catch {stdlog "$bad"}
    stdlog "cpp : Done Event/Logger"
    set DONE_CMDEVT 1
+   if { $subsys == "Test" } {
+      exec cp $SAL_DIR/code/templates/Makefile.sacpp_TestWithSalobj $SAL_WORK_DIR/$subsys/cpp/src/.
+      exec cp $SAL_DIR/code/templates/sacpp_TestWithSalobj.cpp $SAL_WORK_DIR/$subsys/cpp/src/.
+      cd $SAL_WORK_DIR/$subsys/cpp/src
+      exec make -f Makefile.sacpp_TestWithSalobj
+   }
    cd $SAL_WORK_DIR
   }
   if { $OPTIONS(verbose) } {stdlog "###TRACE<<< salcpptestgen $base $id"}

--- a/lsstsal/scripts/gensimplesample.tcl
+++ b/lsstsal/scripts/gensimplesample.tcl
@@ -1092,6 +1092,7 @@ global SAL_WORK_DIR SAL_DIR OPTIONS DONE_CMDEVT
    if { $base == "Test" } {
       exec cp $SAL_DIR/code/templates/Makefile.sacpp_TestWithSalobj $SAL_WORK_DIR/$base/cpp/src/.
       exec cp $SAL_DIR/code/templates/sacpp_TestWithSalobj.cpp $SAL_WORK_DIR/$base/cpp/src/.
+      exec cp $SAL_DIR/code/templates/sacpp_TestWithSalobjTarget.cpp $SAL_WORK_DIR/$base/cpp/src/.
       cd $SAL_WORK_DIR/$base/cpp/src
       exec make -f Makefile.sacpp_TestWithSalobj
    }

--- a/lsstsal/scripts/gensimplesample.tcl
+++ b/lsstsal/scripts/gensimplesample.tcl
@@ -1055,7 +1055,7 @@ global SAL_WORK_DIR OPTIONS
 }
 
 #
-## Documented proc \c saljavaclassgen .
+## Documented proc \c salcppclassgen .
 # \param[in] base Name of CSC/SUbsystem as defined in SALSubsystems.xml
 # \param[in] id Topic identifier
 #
@@ -1089,10 +1089,10 @@ global SAL_WORK_DIR SAL_DIR OPTIONS DONE_CMDEVT
    catch {stdlog "$bad"}
    stdlog "cpp : Done Event/Logger"
    set DONE_CMDEVT 1
-   if { $subsys == "Test" } {
-      exec cp $SAL_DIR/code/templates/Makefile.sacpp_TestWithSalobj $SAL_WORK_DIR/$subsys/cpp/src/.
-      exec cp $SAL_DIR/code/templates/sacpp_TestWithSalobj.cpp $SAL_WORK_DIR/$subsys/cpp/src/.
-      cd $SAL_WORK_DIR/$subsys/cpp/src
+   if { $base == "Test" } {
+      exec cp $SAL_DIR/code/templates/Makefile.sacpp_TestWithSalobj $SAL_WORK_DIR/$base/cpp/src/.
+      exec cp $SAL_DIR/code/templates/sacpp_TestWithSalobj.cpp $SAL_WORK_DIR/$base/cpp/src/.
+      cd $SAL_WORK_DIR/$base/cpp/src
       exec make -f Makefile.sacpp_TestWithSalobj
    }
    cd $SAL_WORK_DIR

--- a/lsstsal/scripts/mavenize.tcl
+++ b/lsstsal/scripts/mavenize.tcl
@@ -149,6 +149,7 @@ global env SAL_WORK_DIR SAL_DIR OSPL_VERSION XMLVERSION RELVERSION TS_SAL_DIR
   exec cp $SAL_DIR/../lib/junit.jar $SAL_WORK_DIR/maven/libs/.
   if { $subsys == "Test" } {
     exec cp $SAL_DIR/code/templates/TestWithSalobjTest.java $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease]/src/test/java/.
+    exec cp $SAL_DIR/code/templates/TestWithSalobjTargetTest.java $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease]/src/test/java/.
   }
 }
 

--- a/lsstsal/scripts/mavenize.tcl
+++ b/lsstsal/scripts/mavenize.tcl
@@ -147,6 +147,9 @@ global env SAL_WORK_DIR SAL_DIR OSPL_VERSION XMLVERSION RELVERSION TS_SAL_DIR
   exec mkdir -p $SAL_WORK_DIR/maven/libs
   exec cp $env(OSPL_HOME)/jar/dcpssaj.jar $SAL_WORK_DIR/maven/libs/.
   exec cp $SAL_DIR/../lib/junit.jar $SAL_WORK_DIR/maven/libs/.
+  if { $subsys == "Test" } {
+    exec cp $SAL_DIR/code/templates/TestWithSalobjTest.java $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease]/src/test/java/.
+  }
 }
 
 

--- a/lsstsal/scripts/parseXML.tcl
+++ b/lsstsal/scripts/parseXML.tcl
@@ -29,15 +29,13 @@ global TLMS TLM_ALIASES EVENT_ENUM EVENT_ENUMS UNITS ENUM_DONE SYSDIC DESC OPTIO
    set checkGenerics 0
    set subsys [lindex [split [file tail $fname] _] 0]
    if { [lindex [split $fname "_."] 1] == "Generics" } {
-     if { [info exists SYSDIC([set subsys],hasAllGenerics)] == 0} {
-       if { $OPTIONS(verbose) } {stdlog "###TRACE------ Checking which generics are in use"}
-       set checkGenerics 1
-       if { [info exists SYSDIC([set subsys],genericsUsed)] } {
-         set gflag [split $SYSDIC([set subsys],genericsUsed) ,]
-         foreach g $gflag {
-            set chkg [string trim $g]
-            set genericsUsed([set subsys]_[set chkg]) 1
-         }
+     if { $OPTIONS(verbose) } {stdlog "###TRACE------ Checking which generics are in use"}
+     set checkGenerics 1
+     if { [info exists SYSDIC([set subsys],genericsUsed)] } {
+       set gflag [split $SYSDIC([set subsys],genericsUsed) ,]
+       foreach g $gflag {
+          set chkg [string trim $g]
+          set genericsUsed([set subsys]_[set chkg]) 1
        }
      }
    }

--- a/lsstsal/scripts/update_ts_xml_dictionary.tcl
+++ b/lsstsal/scripts/update_ts_xml_dictionary.tcl
@@ -57,6 +57,7 @@ global env SYSDIC SAL_WORK_DIR OPTIONS
   if { $OPTIONS(verbose) } {puts stdout "###TRACE>>> parseSystemDictionary"}
   set SYSDIC(systems) ""
   getValidGenerics
+  buildGenericCategories
   set fin [open $env(SAL_WORK_DIR)/SALSubsystems.xml r]
   while { [gets $fin rec] > -1 } {
       set tag   [lindex [split $rec "<>"] 1]
@@ -67,6 +68,7 @@ global env SYSDIC SAL_WORK_DIR OPTIONS
       }
       if { $tag == "Description" } {
          set SYSDIC($name,Description) $value
+         set SYSDIC($name,genericsUsed) $SYSDIC(Category,mandatory)
       }
       if { $tag == "AddedGenerics" } {
          addGenerics $name $value
@@ -150,7 +152,6 @@ global SYSDIC
 #
 proc addGenerics { name glist } {
 global SYSDIC
-  buildGenericCategories
   catch {unset SYSDIC($name,hasAllGenerics)}
   set SYSDIC($name,genericsUsed) $SYSDIC(Category,mandatory)
   if { $glist != "" } {


### PR DESCRIPTION
A proper test needs Russell to change ts_salobj, so I will add a couple of points in the new sprint to deal
with the actual sal<--->salobj testing part