### PR TITLE
Change inter-language cpp/java tests to run in place

### DIFF
--- a/bin/minimal_cpp_commander.sh
+++ b/bin/minimal_cpp_commander.sh
@@ -6,4 +6,4 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting CPP minimal commander"
-/opt/lsst/ts_sal/bin/sacpp_TestWithSalobjTarget $1 $2
+$SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobjTarget $1 $2

--- a/bin/minimal_cpp_controller.sh
+++ b/bin/minimal_cpp_controller.sh
@@ -6,4 +6,4 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting CPP minimal controller"
-/opt/lsst/ts_sal/bin/sacpp_TestWithSalobj $1 $2
+$SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobj $1 $2

--- a/bin/minimal_java_commander.sh
+++ b/bin/minimal_java_commander.sh
@@ -6,5 +6,5 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting Java minimal commander"
-cd /opt/lsst/ts_sal/maven/Test
+cd $SAL_WORK_DIR/maven/Test
 mvn -Dindex=$1 -DlogLevel=$2 -Dtest=TestWithSalobjTargetTest test

--- a/bin/minimal_java_controller.sh
+++ b/bin/minimal_java_controller.sh
@@ -6,5 +6,5 @@ if [ "$#" -ne 2 ]; then
 fi
 
 echo "Starting Java minimal controller"
-cd /opt/lsst/ts_sal/maven/Test
+cd $SAL_WORK_DIR/maven/Test
 mvn -Dindex=$1 -DlogLevel=$2 -Dtest=TestWithSalobjTest test

--- a/lsstsal/scripts/gensalrpms.tcl
+++ b/lsstsal/scripts/gensalrpms.tcl
@@ -40,28 +40,6 @@ global OPTIONS
 
 
 #
-## Documented proc \c copylangtests .
-# \param[in] asset Path a file to include in the RPM
-# \param[in] dest Destination directory for copy
-#
-proc copylangtests { rpmname } {
-global OPTIONS SAL_DIR SALVERSION XMLVERSION RELVERSION SAL_WORK_DIR env
-    set mvnrelease [set XMLVERSION]_[exec cat $env(TS_SAL_DIR)/VERSION][set RELVERSION]
-    if { $OPTIONS(verbose) } {puts stdout "###TRACE>>> copylangtests"}
-    copyasset $SAL_DIR/../../bin/minimal_cpp_commander.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
-    copyasset $SAL_DIR/../../bin/minimal_cpp_controller.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
-    copyasset $SAL_DIR/../../bin/minimal_java_commander.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
-    copyasset $SAL_DIR/../../bin/minimal_java_controller.sh [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
-    copyasset $SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobj [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
-    copyasset $SAL_WORK_DIR/Test/cpp/src/sacpp_TestWithSalobjTarget [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
-    exec mkdir -p [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven
-    exec cp -r $SAL_WORK_DIR/maven/Test-[set mvnrelease] [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven/.
-    exec mv [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven/Test-[set mvnrelease] [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/maven/Test
-    if { $OPTIONS(verbose) } {puts stdout "###TRACE<<< copylangtests"}
-}
-
-
-#
 ## Documented proc \c updatetests .
 # \param[in] subsys Name of CSC/SUbsystem as defined in SALSubsystems.xml
 # \param[in] rpmname Name of the rpm base directory
@@ -88,9 +66,6 @@ global SAL_WORK_DIR XMLVERSION
          copyasset $i [set rpmname]-$XMLVERSION/opt/lsst/ts_sal/bin/.
          puts stdout "Done $subsys $i"
       }
-    }
-    if { $subsys == "Test" } {
-      copylangtests $rpmname
     }
   }
 }

--- a/lsstsal/scripts/mavenize.tcl
+++ b/lsstsal/scripts/mavenize.tcl
@@ -25,6 +25,7 @@ global env SAL_WORK_DIR SAL_DIR OSPL_VERSION XMLVERSION RELVERSION TS_SAL_DIR
   exec mkdir -p $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease]/src/main/java/org/lsst/sal/[set subsys]
   exec mkdir -p $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease]/src/test/java
   exec mkdir -p $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease]/src/main/resources
+  exec ln -sf $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease] $SAL_WORK_DIR/maven/[set subsys]
   set fout [open $SAL_WORK_DIR/maven/[set subsys]-[set mvnrelease]/pom.xml w]
   puts $fout "
 <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"


### PR DESCRIPTION
Removed RPM assets, tests now run in $SAL_WORK_DIR locations