### PR TITLE
Fix java authList.sh bug when java not in runtime list

### DIFF
--- a/lsstsal/scripts/gencommandtestsjava.tcl
+++ b/lsstsal/scripts/gencommandtestsjava.tcl
@@ -299,8 +299,8 @@ echo \"=====================================================================\"
 "
       close $fout
     }
+    exec chmod 755 $SAL_WORK_DIR/[set subsys]/java/src/testAuthList.sh
   }
-  exec chmod 755 $SAL_WORK_DIR/[set subsys]/java/src/testAuthList.sh
   if { $OPTIONS(verbose) } {stdlog "###TRACE<<< genauthlisttestsjava $subsys"}
 }
 


### PR DESCRIPTION
Fix bug where trying to chmod a script not generated for java tests 