### PR TITLE
DM-32956: Improve test_sal.py

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -9,6 +9,16 @@ Version History
 This is release 6.0.0 of the SAL SDK (October 28th 2021)
 -------------------------------------------------------
 
+Changes for 6.0.1
+=================
+
+* Improvements to tests/test_sal.py:
+
+  * The timeout argument was ignored in get_topic.
+  * Improved tests of AddedGenerics.
+    Test that ``Script`` has no ``enable`` command.
+    Test that ``Test`` has no ``enterControl`` command.
+
 Changes for 6.0.0
 =================
 

--- a/tests/test_sal.py
+++ b/tests/test_sal.py
@@ -56,7 +56,7 @@ class BaseSalTestCase(unittest.TestCase):
             Time limit, in seconds.
         """
         start_time = time.time()
-        while time.time() - start_time < 2:
+        while time.time() - start_time < timeout:
             retcode = func(data)
             time.sleep(STD_SLEEP)
             if retcode == SALPY_Test.SAL__OK:
@@ -451,13 +451,15 @@ class BasicTestCase(BaseSalTestCase):
         self.assertEqual(SALPY_Test.arrays_Int0ValueEnum_Five, 5)
 
 
-class ScriptTestCase(unittest.TestCase):
-    """A few tests require CSC that doesn't use generics, so we use Script."""
-
-    def test_generics_no(self):
-        """Test that setting generics to `no` avoids generics."""
-        self.assertFalse(hasattr(SALPY_Script, "Test_command_enterControlC"))
+class AddedGenericsTestCase(unittest.TestCase):
+    def test_no_csc_generics(self):
+        """Test a SAL component that does not have csc in AddedGenerics."""
+        self.assertFalse(hasattr(SALPY_Script, "Test_command_enableC"))
         self.assertFalse(hasattr(SALPY_Script, "Test_logevent_summaryStateC"))
+
+    def test_no_enter_control(self):
+        """Test that enterControl is not present for Test."""
+        self.assertFalse(hasattr(SALPY_Test, "Test_command_enterControlC"))
 
 
 class ErrorHandlingTestCase(BaseSalTestCase):


### PR DESCRIPTION
* Fix a bug in get_topic: the timeout argument was ignored.
* Improve ScriptTestCase: update docs to mention AddedGenerics
  instead of Generics, and test for the enable command
  instead of enterControl, making it a stronger test.