### PR TITLE
u/rowen/DM-32442: improve Java test of AddedGenerics

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,18 +6,16 @@
 Version History
 ###############
 
-This is release 6.0.0 of the SAL SDK (October 28th 2021)
--------------------------------------------------------
-
 Changes for 6.1.0
 =================
 
-* Add Java unit tests for SAL
+* Add Java unit tests for SAL.
 * Improvements to tests/test_sal.py:
 
   * The timeout argument was ignored in get_topic.
-  * Improved tests of AddedGenerics.
-    Test that ``Script`` has no ``enable`` command.
+  * Improved tests of AddedGenerics:
+
+    Test that ``Script`` has no ``enable`` command (instad of ``enterControl``, which is now rare).
     Test that ``Test`` has no ``enterControl`` command.
 
 Changes for 6.0.0

--- a/java_tests/src/test/java/org/lsst/sal/SAL_AddedGenericsTest.java
+++ b/java_tests/src/test/java/org/lsst/sal/SAL_AddedGenericsTest.java
@@ -3,25 +3,24 @@ package org.lsst.sal;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * A few tests require CSC that doesn't use generics, so we use Script.
- */
-public class SAL_ScriptTest {
+public class SAL_AddedGenericsTest {
 
     /**
-     * Test a SAL component that does not have csc in AddedGenerics.
+     * Test topics for a SAL component that does not have "csc" in AddedGenerics.
+     *
+     * Use Script: one of the few SAL component that is not a CSC.
      */
     @Test
-    public void testNoCscGenerics() {
+    public void testNoCsc() {
         Class<?> cls = SAL_Script.class;
         try {
-            cls.getMethod("Test_command_enterControlC", cls);
+            cls.getMethod("Script_command_enableC", cls);
             Assert.fail("A NoSuchMethodException should have been raised.");
         } catch (NoSuchMethodException e) {
             Assert.assertNotNull(e);
         }
         try {
-            cls.getMethod("Test_logevent_summaryStateC", cls);
+            cls.getMethod("Script_logevent_summaryStateC", cls);
             Assert.fail("A NoSuchMethodException should have been raised.");
         } catch (NoSuchMethodException e) {
             Assert.assertNotNull(e);
@@ -29,7 +28,7 @@ public class SAL_ScriptTest {
     }
 
     /**
-     * Test that enterControl is not present for Test.
+     * Test that a standard CSC does not have the "enterControl" command.
      */
     @Test
     public void testNoEnterControl() {

--- a/python/lsst/ts/sal/testutils.py
+++ b/python/lsst/ts/sal/testutils.py
@@ -214,7 +214,8 @@ class TestData:
         import SALPY_Test
 
         empty_arrays = SALPY_Test.Test_arraysC()
-        data.boolean0 = np.random.choice([False, True])
+        # Cast to bool from np._bool to avoid a warning from numpy
+        data.boolean0 = bool(np.random.choice([False, True]))
         printable_chars = [c for c in string.ascii_letters + string.digits]
         # string0 is a string with max length 20 (IDL_Size=20)
         data.string0 = "".join(np.random.choice(printable_chars, size=(20,)))

--- a/tests/test_sal.py
+++ b/tests/test_sal.py
@@ -453,7 +453,7 @@ class BasicTestCase(BaseSalTestCase):
 
 
 class AddedGenericsTestCase(unittest.TestCase):
-    def test_no_csc_generics(self):
+    def test_no_csc(self):
         """Test a SAL component that does not have csc in AddedGenerics."""
         self.assertFalse(hasattr(SALPY_Script, "Test_command_enableC"))
         self.assertFalse(hasattr(SALPY_Script, "Test_logevent_summaryStateC"))


### PR DESCRIPTION
Fix a bug: the Script test was testing Test_x instead of Script_x topics.
Test that Script has no enable command instead of enterControl. That is a stronger test because enterControl is now quite rare (it used to be a standard generic topic).
Rename the test and file, for clarity.

@wvreeven I am worried that this test will fail on any system that doesn't have CLOCK_TAI properly configured:
```
    @Test
    public void testGetLeapSeconds() {
        salUtils salUtil = new salUtils();
        int leapSeconds = salUtil.getLeapSeconds();
        Assert.assertTrue(leapSeconds >= 0);
    }
```
It used to be that the Jenkins computers did not have CLOCK_TAI correctly configured, but if they do now then it might be OK to leave it. However, I think it will also often fail on local user's machines with our Docker images.

If you prefer, we can just delete this test. Sorry I suggested doing otherwise in my prior review. Dave was right that this test probably only makes sense if you have a library like AstroPy that knows the correct TAI.