### PR TITLE
Remove python/lsst/ts/idl

### DIFF
--- a/python/lsst/ts/idl
+++ b/python/lsst/ts/idl
@@ -1,1 +1,0 @@
-/home/rfactory/lsst/ts_idl/python/lsst/ts/idl


### PR DESCRIPTION
which is a symlink and a testing remnant