### PR TITLE
Add QoS related exceptions for Java

### DIFF
--- a/lsstsal/scripts/code/templates/SALDDS.java.template
+++ b/lsstsal/scripts/code/templates/SALDDS.java.template
@@ -284,10 +284,15 @@ public class SAL_SALData {
                    historySync = Integer.parseInt(hname);
                 }
                 if (qname != null) {
-                  commandQos = new QosProvider(qname,"CommandProfile");
-                  eventQos = new QosProvider(qname,"EventProfile");
-                  telemetryQos = new QosProvider(qname,"TelemetryProfile");
-                  ackcmdQos = new QosProvider(qname,"AckcmdProfile");
+                  try {
+                    commandQos = new QosProvider(qname,"CommandProfile");
+                    eventQos = new QosProvider(qname,"EventProfile");
+                    telemetryQos = new QosProvider(qname,"TelemetryProfile");
+                    ackcmdQos = new QosProvider(qname,"AckcmdProfile");
+                  }
+                  catch (NullPointerException e) {
+                    throw new RuntimeException("ERROR : Cannot find file with LSST_DDS_QOS");
+                  }
                 } else {
                    throw new RuntimeException("ERROR : Cannot find envvar LSST_DDS_QOS profiles");
 		}

--- a/lsstsal/scripts/code/templates/salActor.java
+++ b/lsstsal/scripts/code/templates/salActor.java
@@ -133,7 +133,7 @@ public class salActor {
 	this.isEventWriter = false;
 	this.isProcessor = false;
         this.historyDepth = 100;
-        this.maxSamples = 999999999;
+        this.maxSamples = DDS.LENGTH_UNLIMITED.value;
     }
 }
 

--- a/lsstsal/scripts/gensalgetput.tcl
+++ b/lsstsal/scripts/gensalgetput.tcl
@@ -443,6 +443,7 @@ proc addActorIndexesJava { idlfile base fout } {
       puts $fout "    sal\[$idx\].topicName=\"[set base]_[set name]\";"
       if { $type == "logevent" } {
         puts $fout "    status = eventQos.get_topic_qos(sal\[$idx\].topicQos, null);"
+        puts $fout "    if ( status != 0 ) {throw new RuntimeException(\"ERROR : Cannot find EventProfile in QoS\"); }"
         puts $fout "    status = eventQos.get_datareader_qos(sal\[$idx\].RQosH, null);"
         puts $fout "    status = eventQos.get_datawriter_qos(sal\[$idx\].WQosH, null);"
         puts $fout "    status = eventQos.get_publisher_qos(sal\[$idx\].pubQos, null);"
@@ -450,6 +451,7 @@ proc addActorIndexesJava { idlfile base fout } {
       } else {
         if { $type == "command" } {
           puts $fout "    status = commandQos.get_topic_qos(sal\[$idx\].topicQos, null);"
+          puts $fout "    if ( status != 0 ) {throw new RuntimeException(\"ERROR : Cannot find CommandProfile in QoS\"); }"
           puts $fout "    status = commandQos.get_datareader_qos(sal\[$idx\].RQosH, null);"
           puts $fout "    status = commandQos.get_datawriter_qos(sal\[$idx\].WQosH, null);"
           puts $fout "    status = commandQos.get_publisher_qos(sal\[$idx\].pubQos, null);"
@@ -458,6 +460,7 @@ proc addActorIndexesJava { idlfile base fout } {
         } else {
           if { $type == "ackcmd" } {
             puts $fout "    status = ackcmdQos.get_topic_qos(sal\[$idx\].topicQos, null);"
+            puts $fout "    if ( status != 0 ) {throw new RuntimeException(\"ERROR : Cannot find AckcmdProfile in QoS\"); }"
             puts $fout "    status = ackcmdQos.get_datareader_qos(sal\[$idx\].RQosH, null);"
             puts $fout "    status = ackcmdQos.get_datawriter_qos(sal\[$idx\].WQosH, null);"
             puts $fout "    status = ackcmdQos.get_publisher_qos(sal\[$idx\].pubQos, null);"
@@ -465,6 +468,7 @@ proc addActorIndexesJava { idlfile base fout } {
             puts $fout "    status = ackcmdQos.get_topic_qos(sal\[$idx\].topicQos2, null);"
           } else {
             puts $fout "    status = telemetryQos.get_topic_qos(sal\[$idx\].topicQos, null);"
+            puts $fout "    if ( status != 0 ) {throw new RuntimeException(\"ERROR : Cannot find TelemetryProfile in QoS\"); }"
             puts $fout "    status = telemetryQos.get_datareader_qos(sal\[$idx\].RQosH, null);"
             puts $fout "    status = telemetryQos.get_datawriter_qos(sal\[$idx\].WQosH, null);"
             puts $fout "    status = telemetryQos.get_publisher_qos(sal\[$idx\].pubQos, null);"


### PR DESCRIPTION
The missing QoS file exception comes from inside DDS so not easy to change
The late joiner thing I do not understand, getEvent and getNextSample should 
both step through the historical events if present, can you double check against the
python test for this one.