### PR TITLE
Removed references to unsignedLong0 from unit tests

### DIFF
--- a/cpp_tests/test_Test.cpp
+++ b/cpp_tests/test_Test.cpp
@@ -50,7 +50,6 @@ void fillScalarsWithRandom(scalar *data) {
     data->longLong0 = random();
     data->unsignedShort0 = random() & 0xFFFF;
     data->unsignedInt0 = random() & 0xFFFFFFFF;
-    data->unsignedLong0 = random();
     data->float0 = random() / 10000.0;
     data->double0 = random() / 10000.0;
     data->string0 = "Test";
@@ -81,7 +80,6 @@ void fillArraysWithRandomValues(array *data) {
 	data->longLong0[i] = random();
 	data->unsignedShort0[i] = random() & 0xFFFF;
 	data->unsignedInt0[i] = random() & 0xFFFFFFFF;
-	data->unsignedLong0[i] = random();
 	data->float0[i] = random() / 10000.0;
 	data->double0[i] = random() / 10000.0;
     }

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -9,7 +9,8 @@ Version History
 Changes for 7.4.1
 =================
 
-Add timeout field inclusion for C++ ackCommand's
+* Add timeout field inclusion for C++ ackCommand's
+* Removed references from C++ and Java unit tests
 
 Changes for 7.4.0
 =================

--- a/java_tests/src/test/java/org/lsst/sal/TestUtils.java
+++ b/java_tests/src/test/java/org/lsst/sal/TestUtils.java
@@ -16,7 +16,6 @@ public final class TestUtils {
         public long longLong0;
         public short unsignedShort0;
         public int unsignedInt0;
-        public int unsignedLong0;
         public float float0;
         public double double0;
         public String string0;
@@ -31,7 +30,6 @@ public final class TestUtils {
         public long[] longLong0 = new long[5];
         public short[] unsignedShort0 = new short[5];
         public int[] unsignedInt0 = new int[5];
-        public int[] unsignedLong0 = new int[5];
         public float[] float0 = new float[5];
         public double[] double0 = new double[5];
     }
@@ -90,7 +88,6 @@ public final class TestUtils {
         cls.getField("longLong0").set(data, longs);
         cls.getField("unsignedShort0").set(data, shorts);
         cls.getField("unsignedInt0").set(data, ints);
-        cls.getField("unsignedLong0").set(data, ints);
         cls.getField("float0").set(data, floats);
         cls.getField("double0").set(data, doubles);
     }
@@ -115,7 +112,6 @@ public final class TestUtils {
         cls.getField("longLong0").set(data, random.nextLong());
         cls.getField("unsignedShort0").set(data, (short) random.nextInt(1 << 16));
         cls.getField("unsignedInt0").set(data, random.nextInt());
-        cls.getField("unsignedLong0").set(data, random.nextInt());
         cls.getField("float0").set(data, random.nextFloat());
         cls.getField("double0").set(data, random.nextDouble());
     }
@@ -135,7 +131,7 @@ public final class TestUtils {
         Class<?> cls1 = scalars1.getClass();
         Class<?> cls2 = scalars2.getClass();
         String[] fieldNames = {"boolean0", "byte0", "short0", "int0", "long0", "longLong0", "unsignedShort0",
-                "unsignedInt0", "unsignedLong0", "float0", "double0"};
+                "unsignedInt0", "float0", "double0"};
         for (String fieldName : fieldNames) {
             if (!cls1.getField(fieldName).get(scalars1).equals(cls2.getField(fieldName).get(scalars2))) {
                 throw new RuntimeException("Values for field " + fieldName + " are not the same.");
@@ -173,8 +169,6 @@ public final class TestUtils {
                 "unsignedShort0").get(arrays2));
         Assert.assertArrayEquals((int[]) cls1.getField("unsignedInt0").get(arrays1), (int[]) cls2.getField(
                 "unsignedInt0").get(arrays2));
-        Assert.assertArrayEquals((int[]) cls1.getField("unsignedLong0").get(arrays1), (int[]) cls2.getField(
-                "unsignedLong0").get(arrays2));
         Assert.assertTrue(Arrays.equals((float[]) cls1.getField("float0").get(arrays1), (float[]) cls2.getField(
                 "float0").get(arrays2)));
         Assert.assertTrue(Arrays.equals((double[]) cls1.getField("double0").get(arrays1), (double[]) cls2.getField(


### PR DESCRIPTION
This data type is no longer supported.
* Removed from cpp_tests/test_Test.cpp
* Removed from java_tests/src/test/java/org/lsst/sal/TestUtils.java