### PR TITLE
Align SAL Kafka C++ consumer group.id naming with SALOBJ patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,13 @@ Then run the LabVIEW GUI and import the
 `$SAL_WORK_DIR/MTMount/labview/SALLV_<component_name>.so` shared library
 
 Then run the ts_SALLabVIEW VI to generate the .lvlib and VI's
+
+## Kafka Consumer Group Naming
+
+SAL Kafka C++ clients use SALOBJ-compatible consumer group naming, derived
+automatically from the `CSC_identity` and `target_csc_name` set at construction:
+
+- **Self-related topics** (identity matches target CSC): `<user@host>-<Target CSC>-<random>`
+  - `SAL_MTMount()` or `SAL_MTMount(1)` → `saluser@hostname-MTMount-abc123def456789`
+- **Cross-CSC consumption** (identity differs from target CSC): `<Owning CSC>-<Target CSC>-<random>`
+  - `SAL_MTMount(1, "MTPtg")` → `MTPtg-MTMount-abc123def456789`

--- a/lsstsal/scripts/code/templates/SALKAFKA.cpp.template
+++ b/lsstsal/scripts/code/templates/SALKAFKA.cpp.template
@@ -7,12 +7,15 @@
 #include <time.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <string>
+#include <algorithm>
 #include "SAL_SALData.h"
 #include "SAL_SALData_actors.h"
 
 SAL_SALData::SAL_SALData()
 {
    strncpy(CSC_identity, "SALData", 128);
+   strncpy(target_csc_name, "SALData", 128);
    initSalEnvironment(0);
 }
 
@@ -25,6 +28,7 @@ SAL_SALData::SAL_SALData(int aKey, char *identity)
      sprintf(id,"%s",identity);
    }
    strncpy(CSC_identity, id, 128);
+   strncpy(target_csc_name, "SALData", 128);
    initSalEnvironment(aKey);
 }
 
@@ -33,6 +37,7 @@ SAL_SALData::SAL_SALData(int aKey)
    char *id = (char *)malloc(128);
    sprintf(id,"SALData:%d",aKey);
    strncpy(CSC_identity, id, 128);
+   strncpy(target_csc_name, "SALData", 128);
    initSalEnvironment(aKey);
 }
 
@@ -43,6 +48,7 @@ SAL_SALData::SAL_SALData(char *identity)
    } else {
      strncpy(CSC_identity, identity, 128);
    }
+   strncpy(target_csc_name, "SALData", 128);
    initSalEnvironment(0);
 }
 
@@ -146,9 +152,46 @@ void SAL_SALData::initSalEnvironment(int aKey)
     consumerConfiguration->set("sasl.password",securityPassword, errstr);   
   }
   consumerConfiguration->set("value.serializer", "io.confluent.kafka.serializers.KafkaAvroDeserializer", errstr);  // Serialize the Avro object
-  std::string ul = "_";
+  
+  // Build SALOBJ-compatible group.id from CSC_identity and target_csc_name.
+  //
+  // CSC_identity is set by the constructor:
+  //   SAL_X()          -> "X"         (default, same as target)
+  //   SAL_X(1)         -> "X:1"       (indexed, same CSC)
+  //   SAL_X(1,"MTPtg") -> "MTPtg"    (cross-CSC: MTPtg reading X)
+  //
+  // When identity matches the target CSC (default or indexed), the caller
+  // is reading its own topics, so we use user@hostname as the entity.
+  // When identity differs, it was explicitly set by a different CSC,
+  // so we use it directly as the owning CSC name.
+  
+  std::string identityStr = CSC_identity;
+  std::string targetCscStr = target_csc_name;
   std::string randomtag = randomString(15);
-  kafkaGroupId = CSC_identity + ul + randomtag;
+  
+  // Check if identity matches the target CSC (with or without :index suffix)
+  bool isSelfRelated = (identityStr == targetCscStr)
+      || (identityStr.rfind(targetCscStr + ":", 0) == 0);
+  
+  if (!isSelfRelated) {
+    // Cross-CSC: identity was set to a different CSC name
+    kafkaGroupId = identityStr + "-" + targetCscStr + "-" + randomtag;
+  } else {
+    // Self-related default: synthesize user@short-hostname
+    char hostname[256] = {0};
+    gethostname(hostname, sizeof(hostname) - 1);
+    const char* user = getenv("USER");
+    std::string entity = (user ? std::string(user) : std::string("saluser"));
+    entity += "@";
+    entity += hostname;
+    // Strip domain to match SALOBJ behavior
+    auto dotPos = entity.find('.');
+    if (dotPos != std::string::npos) {
+      entity.erase(dotPos);
+    }
+    kafkaGroupId = entity + "-" + targetCscStr + "-" + randomtag;
+  }
+  
   consumerConfiguration->set("group.id",kafkaGroupId, errstr);
   producerConfiguration->set("client.id",CSC_identity, errstr);
 

--- a/lsstsal/scripts/code/templates/SALKAFKA.h.template
+++ b/lsstsal/scripts/code/templates/SALKAFKA.h.template
@@ -220,6 +220,8 @@
       int cmdevtFlushMS;
 ///   Holds the private_identity of this SAL Object, set at creation
       char CSC_identity[128];
+///   Holds the target CSC name (subsystem) for this SAL Object, used in group.id construction
+      char target_csc_name[128];
     public:
 
 /** Constructor for the SAL_SALData object.


### PR DESCRIPTION
Align SAL Kafka C++ consumer group.id naming with SALOBJ patterns
The C++ SAL layer previously set Kafka consumer group.id to just
<CSC_identity>_<random> (e.g. Test:1_abc123), which did not identify
who the owning process or CSC was.

This change derives the group.id from CSC_identity and target_csc_name,
matching SALOBJ's naming convention:

- Self-related (identity matches target CSC):
    <user@short-hostname>-<Target CSC>-<random>
    e.g. saluser@host-MTMount-abc123def456789

- Cross-CSC (identity differs from target CSC):
    <Owning CSC>-<Target CSC>-<random>
    e.g. MTPtg-MTMount-abc123def456789

The cross-CSC case is triggered automatically when the caller passes
an explicit identity to the constructor (e.g. SAL_MTMount(1, "MTPtg")),
with no environment variables required.

Changes:
- SALKAFKA.h.template: add target_csc_name member to hold CSC base name
- SALKAFKA.cpp.template: new group.id construction logic using
  CSC_identity vs target_csc_name comparison, with user@hostname fallback
- README.md: document the consumer group naming patterns

Tested against a live Kafka broker using the Test CSC, confirming all
naming patterns via kafka-consumer-groups.sh --list.