### PR TITLE
OSW-1875: Support building ts_sal in non-conda environments

### DIFF
--- a/bin/jenkinsfile_ci_test_build.sh
+++ b/bin/jenkinsfile_ci_test_build.sh
@@ -22,6 +22,10 @@ set -euo pipefail
 
 WORKSPACE="${WORKSPACE:-$(pwd)}"
 TS_XML_DIR="${TS_XML_DIR:-/home/saluser/repos/ts_xml}"
+# USER may be unset in minimal container images (e.g. robotsal); derive it
+# from the process credentials so that downstream tools and the shell prompt
+# do not trip on an unbound variable.
+export USER="${USER:-$(id -un)}"
 SIMPLE_SAL_DIR="${WORKSPACE}/simple_sal"
 SIMPLE_SAL_REPO="https://github.com/find-out-org-lsst-camera-simple-sal.git"
 SIMPLE_SAL_BRANCH="${SIMPLE_SAL_BRANCH:-develop}"
@@ -50,16 +54,22 @@ if [ -z "${RUBIN_EUPS_PATH+x}" ]; then
   export RUBIN_EUPS_PATH=""
 fi
 set +u
-# Source only the setup commands, not the interactive shell at the end
-source <(grep -v '/bin/bash' ~/.setup.sh)
+if [ -f ~/.setup.sh ]; then
+  source <(grep -v '/bin/bash' ~/.setup.sh)
+fi
 set -u
 echo "export HOME=\"${WORKSPACE}\""
 export HOME="${WORKSPACE}"
 
 # 2. Make the SAL scripts and build outputs writable
 echo "# In run 2"
-export LSST_SDK_INSTALL="${WORKSPACE}"       # salgenerator, etc.
-export LSST_SAL_PREFIX="${CONDA_PREFIX}"     # libs/headers into the conda env
+export LSST_SDK_INSTALL="${WORKSPACE}"
+# Use CONDA_PREFIX if available (salobj image), else fall back to LSST_SAL_PREFIX
+# which is already set in non-conda images (e.g. robotsal)
+if [ -n "${CONDA_PREFIX:-}" ]; then
+  export LSST_SAL_PREFIX="${CONDA_PREFIX}"
+fi
+export LSST_SAL_PREFIX="${LSST_SAL_PREFIX:?LSST_SAL_PREFIX must be set (via CONDA_PREFIX or environment)}"
 export TS_XML_DIR="${TS_XML_DIR}"
 export LSST_TOPIC_SUBNAME=${LSST_TOPIC_SUBNAME:-test}
 

--- a/bin/salenv_complete.sh
+++ b/bin/salenv_complete.sh
@@ -27,8 +27,10 @@ source "${SCRIPT_DIR}/salenv_kafka.sh"
 
 echo ""
 echo "SAL environment configured:"
-echo "  Conda environment: $(conda info --envs | grep '*' | awk '{print $1}')"
-echo "  CONDA_PREFIX: $CONDA_PREFIX"
+if command -v conda >/dev/null 2>&1; then
+  echo "  Conda environment: $(conda info --envs 2>/dev/null | grep '*' | awk '{print $1}')"
+  echo "  CONDA_PREFIX: ${CONDA_PREFIX:-not set}"
+fi
 echo "  LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 echo ""
 echo "SAL Configuration:"
@@ -42,7 +44,7 @@ echo "  TS_XML_DIR: $TS_XML_DIR"
 echo ""
 echo "Kafka Configuration:"
 echo "  LSST_KAFKA_LOCAL_SCHEMAS: $LSST_KAFKA_LOCAL_SCHEMAS"
-echo "  LSST_KAFKA_BROKER_ADDR: $LSST_KAFKA_BROKER_ADDR"
+echo "  LSST_KAFKA_BROKER_ADDR: ${LSST_KAFKA_BROKER_ADDR:-not set}"
 echo "  LSST_SCHEMA_REGISTRY_URL: $LSST_SCHEMA_REGISTRY_URL"
 echo "  LSST_TOPIC_SUBNAME: $LSST_TOPIC_SUBNAME"
 echo ""
@@ -50,7 +52,7 @@ echo ""
 # Verify critical libraries are available
 echo "Verifying libraries..."
 echo "  LSST_SAL_PREFIX: ${LSST_SAL_PREFIX:-not set}"
-echo "  Checking in: ${LSST_SAL_PREFIX}/lib, ${CONDA_PREFIX}/lib, and LD_LIBRARY_PATH"
+echo "  Checking in: ${LSST_SAL_PREFIX}/lib and LD_LIBRARY_PATH"
 
 # Check libavro in multiple locations
 if ldd $(which python) 2>/dev/null | grep -q libavro; then

--- a/bin/salgeneratorKafka
+++ b/bin/salgeneratorKafka
@@ -195,6 +195,7 @@ if { $OPTIONS(validate) } {
   set all $TSUBSYSTEMS
   stdlog "Processing $all"
   foreach i $all {
+    exec mkdir -p $SAL_WORK_DIR/avro-templates/[set i]
     if { [file exists $env(TS_XML_DIR)/python/lsst/ts/xml/data/sal_interfaces/$i] } {
       set old ""
       catch {set old [glob $SAL_WORK_DIR/$d/[set i]_*.json]}
@@ -297,7 +298,7 @@ exec mkdir -p .salwork
 set TARGETS ""
 if { $OPTIONS(lib) == 0 || $OPTIONS(generate) == 1 } {
   set matches $TSUBSYSTEMS
-  foreach f [glob $SAL_WORK_DIR/avro-templates/[set matches]/[set matches]_*.json] {
+  foreach f [glob -nocomplain $SAL_WORK_DIR/avro-templates/[set matches]/[set matches]_*.json] {
     set TARGETS "$TARGETS [file tail $f]"
   }
   if { $TARGETS == "" } {

--- a/bin/setup_functions.sh
+++ b/bin/setup_functions.sh
@@ -58,8 +58,12 @@ install_system_deps() {
     return 0
 }
 
-# Function to install conda packages
+# Function to install conda packages (skipped if conda is not available)
 install_conda_packages() {
+    if ! command -v conda >/dev/null 2>&1; then
+        echo "##### Skipping conda packages (conda not available, using system packages)"
+        return 0
+    fi
     echo "##### Installing conda packages..."
     conda install -y avro avrocpp libboost librdkafka fmt snappy jansson catch2 maven yaml-cpp spdlog lsst-ts-xml
     # Optional debug tools (may fail in some environments due to EUPS post-link scripts)
@@ -77,17 +81,16 @@ install_conda_packages() {
 # Does nothing when LSST_SAL_PREFIX == CONDA_PREFIX (Jenkins workflow).
 # ============================================================================
 ensure_local_conda_symlinks() {
-    local PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX}}"
+    local PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX:-}}"
     
-    # Skip if installing directly into conda (Jenkins workflow)
-    if [ "$PREFIX" = "$CONDA_PREFIX" ]; then
+    # Skip if conda is not available
+    if [ -z "${CONDA_PREFIX:-}" ]; then
         return 0
     fi
     
-    # Skip if CONDA_PREFIX is not set
-    if [ -z "$CONDA_PREFIX" ]; then
-        echo "WARNING: CONDA_PREFIX not set, cannot create symlinks"
-        return 1
+    # Skip if installing directly into conda (Jenkins workflow)
+    if [ "$PREFIX" = "${CONDA_PREFIX:-}" ]; then
+        return 0
     fi
     
     mkdir -p "$PREFIX"/{lib,include}
@@ -133,7 +136,7 @@ build_avro_c() {
     local ORIG_DIR="$(pwd)"
     
     # Use LSST_SAL_PREFIX if set, otherwise fall back to CONDA_PREFIX
-    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX}}"
+    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX:-}}"
     local AVRO_RELEASE="${AVRO_RELEASE:-1.12.0}"
     
     # Check if we need sudo
@@ -152,6 +155,13 @@ build_avro_c() {
     # Copy C++ impl headers used by SAL wrappers
     $SUDO_CMD mkdir -p "$INSTALL_PREFIX/include"
     $SUDO_CMD cp -r ../../lang/c++/impl "$INSTALL_PREFIX/include/."
+    
+    # Config.hh is generated during C++ build and may already exist at
+    # $INSTALL_PREFIX/include/avro/Config.hh. impl/json/JsonDom.hh includes
+    # it with a relative path, so ensure it's findable from impl/json/.
+    if [ -f "$INSTALL_PREFIX/include/avro/Config.hh" ] && [ ! -f "$INSTALL_PREFIX/include/impl/json/Config.hh" ]; then
+        $SUDO_CMD cp "$INSTALL_PREFIX/include/avro/Config.hh" "$INSTALL_PREFIX/include/impl/json/Config.hh"
+    fi
     
     # Run Avro's build script (may output harmless errors at end)
     ./cmake_avrolib.sh || true
@@ -217,7 +227,7 @@ build_avro_cpp() {
     local ORIG_DIR="$(pwd)"
     
     # Use LSST_SAL_PREFIX if set, otherwise fall back to CONDA_PREFIX
-    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX}}"
+    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX:-}}"
     local AVRO_RELEASE="${AVRO_RELEASE:-1.12.0}"
     
     # Check if we need sudo
@@ -277,7 +287,7 @@ build_avro_cpp() {
 
 # Helper function to copy libserdes artifacts into ts_sal tree
 after_libserdes_install_copy() {
-    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX}}"
+    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX:-}}"
     local SDK_INSTALL="${LSST_SDK_INSTALL:-/home/saluser/repos/ts_sal}"
     
     # Check if we need sudo
@@ -295,7 +305,7 @@ after_libserdes_install_copy() {
 
 # Helper function to copy dependency libraries into ts_sal tree
 copy_dep_libs_to_ts_sal() {
-    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX}}"
+    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX:-}}"
     local SDK_INSTALL="${LSST_SDK_INSTALL:-/home/saluser/repos/ts_sal}"
     
     # Check if we need sudo
@@ -322,7 +332,7 @@ build_libserdes_cpp17() {
     echo "##### Building libserdes (C and C++) with C++17..."
     
     local ORIG_DIR="$(pwd)"
-    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX}}"
+    local INSTALL_PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX:-}}"
     
     # Check if we need sudo
     local SUDO_CMD=""
@@ -346,20 +356,20 @@ build_libserdes_cpp17() {
         cd libserdes
     fi
     
-    # Set up paths for both our local install AND conda dependencies
-    export LIBRARY_PATH="$INSTALL_PREFIX/lib:${CONDA_PREFIX}/lib:${LIBRARY_PATH:-}"
-    export LD_LIBRARY_PATH="$INSTALL_PREFIX/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
-    export CPPFLAGS="-I$INSTALL_PREFIX/include -I${CONDA_PREFIX}/include"
-    export LDFLAGS="-L$INSTALL_PREFIX/lib -L${CONDA_PREFIX}/lib -Wl,-rpath,$INSTALL_PREFIX/lib -Wl,-rpath,${CONDA_PREFIX}/lib"
+    # Set up paths for both our local install AND system/conda dependencies
+    local SYS_LIB="${CONDA_PREFIX:+${CONDA_PREFIX}/lib}"
+    export LIBRARY_PATH="$INSTALL_PREFIX/lib${SYS_LIB:+:$SYS_LIB}:${LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="$INSTALL_PREFIX/lib${SYS_LIB:+:$SYS_LIB}:${LD_LIBRARY_PATH:-}"
+    local SYS_PREFIX="${CONDA_PREFIX:-$INSTALL_PREFIX}"
+    export CPPFLAGS="-I$INSTALL_PREFIX/include -I${SYS_PREFIX}/include"
+    export LDFLAGS="-L$INSTALL_PREFIX/lib -L${SYS_PREFIX}/lib -Wl,-rpath,$INSTALL_PREFIX/lib -Wl,-rpath,${SYS_PREFIX}/lib"
     export CXX="g++ -std=c++17"
     export CXXFLAGS="-std=c++17"
     
-    # Only set LIBS when installing to local/ (persistent dev workflow).
-    # In the Jenkins workflow (LSST_SAL_PREFIX == CONDA_PREFIX), libavro's
-    # dependencies are already in the same lib directory, so mklove finds them.
-    # In the local workflow, we need to explicitly link them for the configure check.
-    local EXTRA_LDFLAGS="-L$INSTALL_PREFIX/lib -L${CONDA_PREFIX}/lib"
-    if [ "$INSTALL_PREFIX" != "$CONDA_PREFIX" ]; then
+    # Only set LIBS when installing to a different prefix than where
+    # dependencies live. When they're in the same directory, mklove finds them.
+    local EXTRA_LDFLAGS="-L$INSTALL_PREFIX/lib -L${SYS_PREFIX}/lib"
+    if [ "$INSTALL_PREFIX" != "$SYS_PREFIX" ]; then
         export LIBS="-ljansson -lz -lsnappy"
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS -ljansson -lz -lsnappy"
     else
@@ -386,8 +396,8 @@ build_libserdes_cpp17() {
     if [ -f Makefile.config ]; then
         sed -i 's/--std=c++11//g' Makefile.config || true
         echo 'CXXFLAGS+= -std=c++17' >> Makefile.config
-        if [ "$INSTALL_PREFIX" != "$CONDA_PREFIX" ]; then
-            echo "LDFLAGS+= -L${CONDA_PREFIX}/lib -Wl,-rpath,${CONDA_PREFIX}/lib" >> Makefile.config
+        if [ "$INSTALL_PREFIX" != "$SYS_PREFIX" ]; then
+            echo "LDFLAGS+= -L${SYS_PREFIX}/lib -Wl,-rpath,${SYS_PREFIX}/lib" >> Makefile.config
         fi
     fi
     

--- a/bin/setup_stack_build.sh
+++ b/bin/setup_stack_build.sh
@@ -15,7 +15,15 @@ echo "##### Setting up SAL Stack-10 build environment"
 # Source version configuration
 source "${SCRIPT_DIR}/sal_versions.sh"
 
-export JAVA_HOME=$CONDA_PREFIX/lib/jvm
+if [ -n "${CONDA_PREFIX:-}" ]; then
+  export JAVA_HOME=$CONDA_PREFIX/lib/jvm
+elif [ -n "${JAVA_HOME:-}" ]; then
+  echo "Using pre-set JAVA_HOME: $JAVA_HOME"
+else
+  # Common system location on RHEL/Rocky
+  export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac 2>/dev/null || echo /usr/lib/jvm/java/bin/javac))))
+  echo "Auto-detected JAVA_HOME: $JAVA_HOME"
+fi
 
 # LSST_SDK_INSTALL: Use existing value if set, otherwise default to ts_sal location
 #                   Points to the ts_sal repository.
@@ -26,9 +34,9 @@ export LSST_SDK_INSTALL=${LSST_SDK_INSTALL:-/home/saluser/repos/ts_sal}
 #   1. Use LSST_SAL_PREFIX if already set
 #   2. Use CONDA_PREFIX if writable
 #   3. Fall back to LSST_SDK_INSTALL if CONDA_PREFIX is not writable
-if [ -n "$LSST_SAL_PREFIX" ]; then
+if [ -n "${LSST_SAL_PREFIX:-}" ]; then
     echo "Using pre-set LSST_SAL_PREFIX: $LSST_SAL_PREFIX"
-elif [ -w "$CONDA_PREFIX/lib" ] || [ "$(id -u)" -eq 0 ]; then
+elif [ -n "${CONDA_PREFIX:-}" ] && { [ -w "$CONDA_PREFIX/lib" ] || [ "$(id -u)" -eq 0 ]; }; then
     export LSST_SAL_PREFIX=$CONDA_PREFIX
     echo "Using CONDA_PREFIX as LSST_SAL_PREFIX: $LSST_SAL_PREFIX"
 else
@@ -49,8 +57,7 @@ main() {
     fi
     
     if ! check_conda; then
-        echo "Error: Conda is required but not found"
-        exit 1
+        echo "Note: Conda not found, using system packages"
     fi
     
     mkdir -p $HOME/external-packages
@@ -58,8 +65,27 @@ main() {
     install_system_deps || echo "Warning: System dependencies installation had errors, continuing anyway..." >&2
     install_conda_packages
     
-    build_avro_c
-    build_libserdes_cpp17
+    local PREFIX="${LSST_SAL_PREFIX:-${CONDA_PREFIX:-}}"
+    if [ -f "$PREFIX/lib/libavro.so" ] && [ -f "$PREFIX/lib/libavro.a" ]; then
+        echo "##### Skipping Avro C build (already installed at $PREFIX/lib)"
+    else
+        build_avro_c
+    fi
+    
+    if [ -f "$PREFIX/lib/libserdes.so.1" ] && [ -f "$PREFIX/lib/libserdes++.so.1" ]; then
+        echo "##### Skipping libserdes build (already installed at $PREFIX/lib)"
+    else
+        build_libserdes_cpp17
+    fi
+    
+    # Ensure Config.hh is findable from impl/json/JsonDom.hh (which uses
+    # a relative #include "Config.hh"). Config.hh lives in avro/ but
+    # impl/json/ is a sibling directory, so the compiler can't find it
+    # unless it's also in impl/json/ or the Makefile adds -I.../avro.
+    if [ -f "$PREFIX/include/avro/Config.hh" ] && [ ! -f "$PREFIX/include/impl/json/Config.hh" ]; then
+        mkdir -p "$PREFIX/include/impl/json"
+        cp "$PREFIX/include/avro/Config.hh" "$PREFIX/include/impl/json/Config.hh"
+    fi
     
     setup_sal_environment "${SCRIPT_DIR}"
     

--- a/cpp_tests/Makefile
+++ b/cpp_tests/Makefile
@@ -17,10 +17,11 @@ CFLAGS := \
 	-I"$(SAL_WORK_DIR)/include" -Wno-write-strings \
 	-I"${CONDA_PREFIX}/include" -I"$(SAL_WORK_DIR)/Test/cpp/src" -I"$(SAL_WORK_DIR)/Script/cpp/src"
 
+SAL_LIB_PREFIX ?= $(if $(LSST_SAL_PREFIX),$(LSST_SAL_PREFIX),$(CONDA_PREFIX))
 LIBS := -L/usr/local/lib64 -lCatch2Main -lCatch2 -L${SAL_WORK_DIR}/lib -lSAL_Test -lSAL_Script \
-	-ldl -lrt -lpthread -L$(CONDA_PREFIX)/lib -L/usr/lib64/boost1.78 -lboost_filesystem -lboost_iostreams \
-	-lboost_program_options -lboost_system $(CONDA_PREFIX)/lib/libserdes++.a \
-	$(CONDA_PREFIX)/lib/libserdes.a -lcurl -ljansson \
+	-ldl -lrt -lpthread -L$(SAL_LIB_PREFIX)/lib -L/usr/lib64/boost1.78 -lboost_filesystem -lboost_iostreams \
+	-lboost_program_options -lboost_system $(SAL_LIB_PREFIX)/lib/libserdes++.a \
+	$(SAL_LIB_PREFIX)/lib/libserdes.a -lcurl -ljansson \
 	-lrdkafka++ -lrdkafka -lavrocpp -lavro -lsasl2
 
 ifneq ($(MAKECMDGOALS),clean)

--- a/lsstsal/scripts/activaterevcodesKafka.tcl
+++ b/lsstsal/scripts/activaterevcodesKafka.tcl
@@ -24,7 +24,10 @@ set SAL_WORK_DIR $env(SAL_WORK_DIR)
 #
 proc updateRevCodes { subsys } {
 global SAL_WORK_DIR REVCODE
-  set ljson [glob $SAL_WORK_DIR/avro-templates/[set subsys]/[set subsys]_*.json]
+  set ljson [glob -nocomplain $SAL_WORK_DIR/avro-templates/[set subsys]/[set subsys]_*.json]
+  if { [llength $ljson] == 0 } {
+    errorexit "No JSON files found in avro-templates/$subsys/ - cannot generate revcodes (ensure ts_xml is installed and get_component_info ran successfully)"
+  }
   set fmd5 [open $SAL_WORK_DIR/avro-templates/[set subsys]_revCodes.tcl w]
   foreach i [lsort $ljson] {
     set c [lindex [exec md5sum $i] 0]


### PR DESCRIPTION

E.g. robotsal image

All changes make conda optional: when conda is not present the build falls back to system packages and a pre-configured LSST_SAL_PREFIX, so the full SAL stack can be built inside images that do not have conda installed.

bin/setup_stack_build.sh
- Do not abort when conda is not found; print a note and continue with system packages instead.
- Derive JAVA_HOME from the system javac when CONDA_PREFIX is unset.
- Guard LSST_SAL_PREFIX / CONDA_PREFIX logic with presence checks so the script works with either a conda env or a plain system prefix.
- Skip Avro C and libserdes builds when the libraries are already present at the install prefix (avoids redundant rebuilds in CI).
- Copy Config.hh into include/impl/json/ after the Avro build so that JsonDom.hh can find it via its relative #include path.

bin/setup_functions.sh
- install_conda_packages: skip gracefully when conda is not available.
- ensure_local_conda_symlinks: guard on CONDA_PREFIX presence rather than on equality with LSST_SAL_PREFIX; works correctly in both conda and non-conda environments.
- build_avro_c / build_avro_cpp / build_libserdes_cpp17 / after_libserdes_install_copy / copy_dep_libs_to_ts_sal: use ${CONDA_PREFIX:-} (empty-default) instead of bare $CONDA_PREFIX so the scripts do not error under set -u when conda is absent.
- build_libserdes_cpp17: derive SYS_PREFIX/SYS_LIB from CONDA_PREFIX when available, otherwise fall back to INSTALL_PREFIX, so compiler and linker flags are correct in both environments.
- build_avro_c: copy Config.hh into include/impl/json/ to fix the relative-include issue in JsonDom.hh.

bin/jenkinsfile_ci_test_build.sh
- Source ~/.setup.sh only when the file exists (not present in all images).
- Set LSST_SAL_PREFIX from CONDA_PREFIX only when CONDA_PREFIX is defined; otherwise rely on the value already provided by the environment (e.g. robotsal sets LSST_SAL_PREFIX directly).

bin/salenv_complete.sh
- Print conda info only when conda is available.
- Use ${VAR:-not set} for CONDA_PREFIX and LSST_KAFKA_BROKER_ADDR so the script does not fail under set -u when they are unset.
- Remove the reference to CONDA_PREFIX in the library-check message since it may not be set.

cpp_tests/Makefile
- Introduce SAL_LIB_PREFIX that resolves to LSST_SAL_PREFIX when set, falling back to CONDA_PREFIX.  All libserdes / lib paths now use SAL_LIB_PREFIX so the test build works with either a conda or a non-conda install prefix.

bin/salgeneratorKafka
- Create avro-templates/<subsys>/ before invoking get_component_info so that the subsequent ls -l does not fail when the command is skipped.
- Use glob -nocomplain when collecting topic JSON files so that missing files produce the clear errorexit message rather than a raw Tcl error.

lsstsal/scripts/activaterevcodesKafka.tcl
- Use glob -nocomplain and errorexit (instead of WARNING + return) when no JSON files exist for a subsystem so the build fails fast with a useful message instead of a cryptic REVCODE variable error later.